### PR TITLE
Updated EncounterType

### DIFF
--- a/Encounters/Discharge disposition/Discharge disposition(C-CDA2.1).xml
+++ b/Encounters/Discharge disposition/Discharge disposition(C-CDA2.1).xml
@@ -20,7 +20,7 @@
                 </thead>
                 <tbody>
                     <tr id="Encounter1">
-                        <td id="Encounter1_Type"> Checkup Examination </td>
+                        <td id="Encounter1_Type"> Inpatient Hospital Care - moderate complexity</td>
                         <td>Performer Name</td>
                         <td>Community Urgent Care Center</td>
                         <td>September 27, 2012 at 1:00pm</td>
@@ -36,7 +36,7 @@
                 <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01"/>
                 <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
                 <id root="2a620155-9d11-439e-92b3-5d9815ff4de8"/>
-                <code code="99213" displayName="Office outpatient visit 15 minutes" codeSystemName="CPT-4" codeSystem="2.16.840.1.113883.6.12">
+                <code code="99221" displayName="Initial hospital care, per day, for the evaluation and management of a patient - 50 minutes" codeSystemName="CPT-4" codeSystem="2.16.840.1.113883.6.12">
                     <originalText>
                         <reference value="#Encounter1_Type"/>
                     </originalText>


### PR DESCRIPTION
Since the discharge disposition is more associated with discharging from in Inpatient visit, I modified the encounter type and updated the narrative text accordingly. I purposely made the original text different than the displayName to show that the human readable concept does not need to be exactly the same as the displayName. It just needs to be dereferenced through the originalText element of the coded concept so the association of content/meaning to the coded concept can be preserved.