### PR TITLE
Add Person Name Formatting example

### DIFF
--- a/Header/Person Name Formatting/Person Name Formatting (C-CDA R2.1).xml
+++ b/Header/Person Name Formatting/Person Name Formatting (C-CDA R2.1).xml
@@ -1,0 +1,30 @@
+<recordTarget>
+    <!-- Note: several other data elements (telecom, address, etc.) are required to meet C-CDA R2.1 requirements -->
+    <patientRole>
+        <id nullFlavor="NI" />
+        <patient>
+            <!-- Don't do this; "Robin Taylor Dr." isn't a logical display order -->
+            <name>
+                <given>Robin</given>
+                <family>Taylor</family>
+                <prefix qualifier="AC TITLE">Dr. </prefix>
+            </name>
+            <!-- Don't do this; "Taylor Robin" is confusing (is Taylor the given name?) -->
+            <name>
+                <family>Taylor</family>
+                <given>Robin</given>
+            </name>
+            <!-- This is okay; "Taylor, Robin" implies Lastname, Firstname ordering in the US -->
+            <name>
+                <family>Taylor</family>
+                <delimiter>, </delimiter>
+                <given>Robin</given>
+            </name>
+            <!-- This is okay; "Robin Taylor" is a logical display order -->
+            <name>
+                <given>Robin</given>
+                <family>Taylor</family>
+            </name>
+        </patient>
+    </patientRole>
+</recordTarget>

--- a/Header/Person Name Formatting/Person Name Formatting (C-CDA R2.1).xml
+++ b/Header/Person Name Formatting/Person Name Formatting (C-CDA R2.1).xml
@@ -1,18 +1,13 @@
 <recordTarget>
-    <!-- Note: several other data elements (telecom, address, etc.) are required to meet C-CDA R2.1 requirements -->
+    <!-- Examples of how systems send names and logical display order -->
+    <!-- Note: This snippet omits other data elements required to meet C-CDA R2.1 requirements (telecom, address, etc.) -->
     <patientRole>
         <id nullFlavor="NI" />
         <patient>
-            <!-- Don't do this; "Robin Taylor Dr." isn't a logical display order -->
+            <!-- This is okay; "Robin Taylor" is a logical display order -->
             <name>
                 <given>Robin</given>
                 <family>Taylor</family>
-                <prefix qualifier="AC TITLE">Dr. </prefix>
-            </name>
-            <!-- Don't do this; "Taylor Robin" is confusing (is Taylor the given name?) -->
-            <name>
-                <family>Taylor</family>
-                <given>Robin</given>
             </name>
             <!-- This is okay; "Taylor, Robin" implies Lastname, Firstname ordering in the US -->
             <name>
@@ -20,10 +15,28 @@
                 <delimiter>, </delimiter>
                 <given>Robin</given>
             </name>
-            <!-- This is okay; "Robin Taylor" is a logical display order -->
+            <!-- This is okay; "Dr. Robin Taylor" is a logical display order -->
+            <name>
+                <prefix qualifier="AC TITLE">Dr. </prefix><!-- Space in element is intentional (see CDA R2.0 Section 2.23.4) -->
+                <given>Robin</given>
+                <family>Taylor</family>
+            </name>
+            <!-- This is okay; "Robin Taylor MD" is a logical display order -->
             <name>
                 <given>Robin</given>
                 <family>Taylor</family>
+                <suffix qualifier="AC TITLE"> MD</suffix><!-- Space in element is intentional (see CDA R2.0 Section 2.23.4) -->
+            </name>
+            <!-- Don't do this; "Robin Taylor Dr." isn't a logical display order -->
+            <name>
+                <given>Robin</given>
+                <family>Taylor</family>
+                <prefix qualifier="AC TITLE">Dr. </prefix><!-- Space in element is intentional -->
+            </name>            
+            <!-- Don't do this; "Taylor Robin" is confusing (is Taylor the given name?) -->
+            <name>
+                <family>Taylor</family>
+                <given>Robin</given>
             </name>
         </patient>
     </patientRole>

--- a/Header/Person Name Formatting/Readme.md
+++ b/Header/Person Name Formatting/Readme.md
@@ -1,0 +1,32 @@
+## Approval Status
+
+Approval Status: Approved
+
+Example Task Force: 8/29/2019
+
+### C-CDA 2.1 Example:
+
+US Realm Patient Name (PTN.US.FIELDED) 2.16.840.1.113883.10.20.22.5.1
+
+### Reference to full CDA sample:
+
+N/A
+### Validation location
+
+N/A
+### Comments
+
+This example demonstrates the idea that name pieces should be sent in a logical display order (ie such that a receiver which only extracts the text and ignores the markup around `<given>`, `<family>`, etc. would still display the name in a way a human would interpret correctly).
+### Custodian
+
+Matt Szczepankiewicz mszczepa@epic.com (GitHub: mjszczep)
+
+### Keywords
+
+Demographics, Name, 
+### Permalink
+
+[TBD]
+### Links
+
+Person Name Formatting (C-CDA R2.1).xml

--- a/Header/Person Name Formatting/Readme.md
+++ b/Header/Person Name Formatting/Readme.md
@@ -23,7 +23,7 @@ Matt Szczepankiewicz mszczepa@epic.com (GitHub: mjszczep)
 
 ### Keywords
 
-Demographics, Name, 
+Demographics, Name, Formatting
 ### Permalink
 
 [TBD]

--- a/Header/Person Name Formatting/Readme.md
+++ b/Header/Person Name Formatting/Readme.md
@@ -1,8 +1,10 @@
 ## Approval Status
 
-Approval Status: Approved
+Approval Status: Pending
 
 Example Task Force: 8/29/2019
+
+SDWG:
 
 ### C-CDA 2.1 Example:
 
@@ -24,9 +26,7 @@ Matt Szczepankiewicz mszczepa@epic.com (GitHub: mjszczep)
 ### Keywords
 
 Demographics, Name, Formatting
-### Permalink
 
-[TBD]
 ### Links
 
 Person Name Formatting (C-CDA R2.1).xml


### PR DESCRIPTION
Create `Header/Person Name Formatting/Person Name Formatting (C-CDA R2.1).xml` to demonstrate the idea that name pieces should be sent in a logical display order (ie such that a receiver which only extracts the text and ignores the markup around `<given>`, `<family>`, etc. would still display the name in a way a human would interpret correctly).