### PR TITLE
Patient Aliases

### DIFF
--- a/Header/Patient Aliases/Patient Aliases (C-CDA R2.1).xml
+++ b/Header/Patient Aliases/Patient Aliases (C-CDA R2.1).xml
@@ -1,0 +1,22 @@
+<recordTarget>
+    <!-- Best practices for sending one or more patient aliases -->
+    <!-- Note: This snippet omits other data elements required to meet C-CDA R2.1 requirements (telecom, address, etc.) -->
+    <patientRole>
+        <id nullFlavor="NI" />
+        <patient>
+            <!-- SHALL contain at least one [1..*] US Realm Patient Name (CONF:1198-5284) -->
+            <name use="L">
+                <given>Deirdre</given>
+                <family>Jones</family>
+            </name>
+            <!-- Recommended way to send patient aliases; note @use='P' (pseudonym) and given/@qualifier='CL' (callme) -->
+            <name use="P">
+                <given qualifier="CL">Dee</given>
+                <family>Jones</family>
+            </name>
+            <!-- At least one US Realm Patient Name (with given, family, etc) is required,
+                 but other aliases may also be sent as free text if necessary. -->
+            <name>Deirdre Batcher</name>
+        </patient>
+    </patientRole>
+</recordTarget>

--- a/Header/Patient Aliases/Patient Aliases (C-CDA R2.1).xml
+++ b/Header/Patient Aliases/Patient Aliases (C-CDA R2.1).xml
@@ -14,9 +14,6 @@
                 <given qualifier="CL">Dee</given>
                 <family>Jones</family>
             </name>
-            <!-- At least one US Realm Patient Name (with given, family, etc) is required,
-                 but other aliases may also be sent as free text if necessary. -->
-            <name>Deirdre Batcher</name>
         </patient>
     </patientRole>
 </recordTarget>

--- a/Header/Patient Aliases/Readme.md
+++ b/Header/Patient Aliases/Readme.md
@@ -1,0 +1,32 @@
+## Approval Status
+
+Approval Status: Pending
+
+Example Task Force: 11/7/2019
+
+SDWG:
+
+### C-CDA 2.1 Example:
+
+US Realm Patient Name (PTN.US.FIELDED) 2.16.840.1.113883.10.20.22.5.1
+
+### Reference to full CDA sample:
+
+N/A
+### Validation location
+
+N/A
+### Comments
+
+Best practices for sending one or more patient aliases
+### Custodian
+
+Matt Szczepankiewicz mszczepa@epic.com (GitHub: mjszczep)
+
+### Keywords
+
+Demographics, Name, Aliases, Callme
+
+### Links
+
+Patient Aliases (C-CDA R2.1).xml


### PR DESCRIPTION
Hey Brett--here's a quick example of patient aliases (callme names) to go over on the next examples task force call.

This is based on my interpretation of CDA + C-CDA, but some of it should probably be open for discussion. In particular, sending the patient's legal and callme names as two separate name elements contradicts Figure 238 of the most recent C-CDA IG, but I think it's more in line with the CDA EntityName rules. Likewise, the ONC C-CDA validator regards free-text patient names as invalid, but it seems to me like they're allowed here. Hope we can talk about it!