### PR TITLE
Readme updates

### DIFF
--- a/Allergies/Allergy to food egg/Readme.md
+++ b/Allergies/Allergy to food egg/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 4/17/2014
@@ -7,7 +7,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
@@ -17,33 +17,33 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a food allergy with information on both allergic reaction and reaction severity. It was based upon discussion with Russ Leftwich and Lisa Nelson in coordination with Patient Care Committee. See DSTU 219 for update regarding act/code.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/9731b470c5291fabfafb97268bdc0820f0058bc9](http://cdasearch.hl7.org/examples/view/9731b470c5291fabfafb97268bdc0820f0058bc9)
 
-###Links
+### Links
 
 * [Allergy to food egg(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20food%20egg/Allergy%20to%20food%20egg%28C-CDA2.1%29.xml)

--- a/Allergies/Allergy to latex/Readme.md
+++ b/Allergies/Allergy to latex/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/17/2014
@@ -7,7 +7,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
@@ -17,33 +17,33 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a propensity to substance allergy with information on both allergic reaction and reaction severity. It was based upon discussion with Russ Leftwich and Lisa Nelson in coordination with Patient Care Committee. See DSTU 219 for update regarding act/code.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/0887da225cc90d3c781ca1b3fad76b2a6c49eaea](http://cdasearch.hl7.org/examples/view/0887da225cc90d3c781ca1b3fad76b2a6c49eaea)
 
-###Links
+### Links
 
 * [Allergy to specific substance latex(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20latex/Allergy%20to%20specific%20substance%20latex%28C-CDA2.1%29.xml)

--- a/Allergies/Allergy to specific drug Codeine/Readme.md
+++ b/Allergies/Allergy to specific drug Codeine/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/17/2014
@@ -7,7 +7,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
@@ -17,30 +17,30 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a propensity to drug adverse event with information on multiple allergic reactions each with reaction severity. It was based upon discussion with Rob Hausam and John D'Amore and Russ Leftwich in coordination with Patient Care Committee. This sample replaces the Epinephrine sample which had less clinical accuracy/relevance. See DSTU 219 for update regarding act/code.
-###Custodian
+### Custodian
 
 * Lisa R. Nelson LisaRNelson@cox.net (GitHub: lisarnelson)
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/a27d1dc926d1a104a321c883d845af26583d06a9](http://cdasearch.hl7.org/examples/view/a27d1dc926d1a104a321c883d845af26583d06a9)
 
-###Links
+### Links
 
 * [Allergy to specific drug Codeine(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20specific%20drug%20Codeine/Allergy%20to%20specific%20drug%20Codeine%28C-CDA2.1%29.xml)

--- a/Allergies/Allergy to specific drug Penicillin/Readme.md
+++ b/Allergies/Allergy to specific drug Penicillin/Readme.md
@@ -1,11 +1,12 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/10/2014
-* SDWG: 4/24/2014
+
+* SDWG: 4/24/2014
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
@@ -16,34 +17,34 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of an allergy to a specific drug (penicillin) using RxNorm as terminology with information on both allergic reaction and reaction severity. For drug allergies, this example illustrates a good practice of encoding the allergen at the ingredient level (penicillin) not administration level (10 mg tablet). See DSTU 219 for update regarding act/code.
 * Multiple reactions are listed in some examples
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/46224f150dee048bc8f907116d285b332739d3a0](http://cdasearch.hl7.org/examples/view/46224f150dee048bc8f907116d285b332739d3a0)
 
-###Links
+### Links
 
 * [Allergy to specific drug Penicillin(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20specific%20drug%20Penicillin/Allergy%20to%20specific%20drug%20Penicillin%28C-CDA2.1%29.xml)

--- a/Allergies/Allergy to specific drug class Penicillins/Readme.md
+++ b/Allergies/Allergy to specific drug class Penicillins/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/10/2014
 * SDWG: 4/24/2014
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 * Allergy Concern Act 2.16.840.1.113883.10.20.22.4.30:2015-08-01
@@ -13,33 +13,33 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of an allergy to a drug class (penicillins) using NDF-RT as terminology with information on both allergic reaction and reaction severity. See DSTU 219 for update regarding act/code
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/9ed071312a5ab1b896dbbe1bca19c72f921a1616](http://cdasearch.hl7.org/examples/view/9ed071312a5ab1b896dbbe1bca19c72f921a1616)
 
-###Links
+### Links
 
 * [Allergy to specific drug class Penicillins(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20specific%20drug%20class%20Penicillins/Allergy%20to%20specific%20drug%20class%20Penicillins%28C-CDA2.1%29.xml)

--- a/Allergies/Free-text Allergy to clinical trial drug/README.md
+++ b/Allergies/Free-text Allergy to clinical trial drug/README.md
@@ -1,10 +1,10 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 4/26/2018
 * SDWG: 10/1/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
@@ -14,29 +14,29 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates an example of allergy to a new drug ingredient which is in a clinical trial phase and not approved by the FDA. As a result, there is no RxNorm, NDF-RT, SNOMED or UNII code.  An NCI thesaurus code is in turn used as a translation code since NCI tracks new chemotherapy drugs in clinical trial phases.
 
 Additional Notes and Assumptions:
 * The example drug, talazoparib, was in clinical trial phase at the time of this example.  It is possible for this drug to be approved at some point in the future after this C-CDA example is approved.
 
-###Custodian
+### Custodian
 
 * May Terry (GitHub: mayterry88)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 

--- a/Allergies/No Known Allergies/Readme.md
+++ b/Allergies/No Known Allergies/Readme.md
@@ -19,7 +19,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 ### Comments

--- a/Allergies/No Known Medication Allergies/Readme.md
+++ b/Allergies/No Known Medication Allergies/Readme.md
@@ -1,44 +1,44 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 10/23/2014
 * SDWG: 11/06/2014
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Allergy Concern Act 2.16.840.1.113883.10.20.22.4.30:2015-08-01
 
 * Allergy Intolerance Observation 2.16.840.1.113883.10.20.22.4.7:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how an author can record a patient has no known medication allergies.
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/ac120035c26ed3fb208bb446c782dc8bc783ab44](http://cdasearch.hl7.org/examples/view/ac120035c26ed3fb208bb446c782dc8bc783ab44)
 
-###Links
+### Links
 
 * [No Known Medication Allergies(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/No%20Known%20Medication%20Allergies/No%20Known%20Medication%20Allergies%28C-CDA2.1%29.xml)

--- a/Allergies/No Section Information Allergies/Readme.md
+++ b/Allergies/No Section Information Allergies/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/30/2017
@@ -6,45 +6,45 @@
 
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6
 * 2.16.840.1.113883.10.20.22.2.6:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.6.1
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no information available for allergies. This example is similar to the No Section Information Problems example. This sample is not approriate for asserting 'No Known Allergies'.
 
-###Certification
+### Certification
 
 * ONC
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * null section, no information section
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a2edaaa31651e000b55a514](http://cdasearch.hl7.org/examples/view/5a2edaaa31651e000b55a514)
 
-###Links
+### Links
 
 * [No Information Allergies(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/No%20Section%20Information%20Allergies/No%20Information%20Allergies%28C-CDA2.1%29.xml)

--- a/Allergies/Not Allergic to Peanuts/Readme.md
+++ b/Allergies/Not Allergic to Peanuts/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/5/2018
 * SDWG: 10/1/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Allergies and Intolerances Section 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 * Allergy Concern Act 2.16.840.1.113883.10.20.22.4.30:2015-08-01
 * Allergy Intolerance Observation 2.16.840.1.113883.10.20.22.4.7:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how an author can record a patient is not allergic to a specific substance. In this example, the susbtance is Peanuts.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 

--- a/Allergies/Readme.md
+++ b/Allergies/Readme.md
@@ -1,1 +1,1 @@
-##Allergies and Intolerances Section Examples from C-CDA 
+## Allergies and Intolerances Section Examples from C-CDA 

--- a/Allergies/Withdrawn Allergy to cat hair/Readme.md
+++ b/Allergies/Withdrawn Allergy to cat hair/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Withdrawn
 * Example Task Force: Approved 4/10/2014
 * SDWG: Withdrawn from consideration since not clinically relevant. The allergy section is used to record drugs, materials or dietary substances that a patient may be exposed to during their course of care.  Allergies to cats, dogs, etc do not occur in that situation.  The cat allergy should be recorded in the Problem section
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
@@ -15,33 +15,33 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of an allergy to a specific substance (cat hair) using UNII as terminology with information on both allergic reaction and reaction severity. See DSTU 219 for update regarding act/code.
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/*ad811b5c30103652f64000ae9a9d7092279d22b3](http://cdasearch.hl7.org/examples/view/*ad811b5c30103652f64000ae9a9d7092279d22b3)
 
 
-###Links
+### Links
 
 * [Allergy to specific substance cat hair(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20cat%20hair/Allergy%20to%20specific%20substance%20cat%20hair%28C-CDA2.1%29.xml)

--- a/Allergies/Withdrawn Allergy to specific drug Epinephrine/Readme.md
+++ b/Allergies/Withdrawn Allergy to specific drug Epinephrine/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Withdrawn
 * Example Task Force: 4/17/2014
 * SDWG: Withdrawn from consideration since not clinically relevant.
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
@@ -15,34 +15,34 @@
 * Reaction Observation 2.16.840.1.113883.10.20.22.4.9:2014-06-09
 * Severity Observation 2.16.840.1.113883.10.20.22.4.8:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Allergies in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a propensity to drug adverse event with information on multiple allergic reactions each with reaction severity. It was based upon discussion with Russ Leftwich and Lisa Nelson in coordination with Patient Care Committee. See DSTU 219 for update regarding act/code.
 * Multiple reactions are listed in some examples
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * substance, allergies, allergy
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/37f3de0affcd46df777333782c8f192f575248ca](http://cdasearch.hl7.org/examples/view/37f3de0affcd46df777333782c8f192f575248ca)
 
-###Links
+### Links
 
 * [Allergy to specific drug Epinephrine(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Allergies/Allergy%20to%20specific%20drug%20Epinephrine/Allergy%20to%20specific%20drug%20Epinephrine%28C-CDA2.1%29.xml)

--- a/Care Team/Readme.md
+++ b/Care Team/Readme.md
@@ -1,1 +1,1 @@
-##Care Team Examples from C-CDA Companion Guide
+## Care Team Examples from C-CDA Companion Guide

--- a/Documents/CCD/CCD 1/Readme.md
+++ b/Documents/CCD/CCD 1/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Continuity of Care Document (CCD) (V2) 2.16.840.1.113883.10.20.22.1.2:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Continuity of Care, C-CDA CCD

--- a/Documents/CCD/CCD 2/Readme.md
+++ b/Documents/CCD/CCD 2/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Continuity of Care Document (CCD) (V2) 2.16.840.1.113883.10.20.22.1.2:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Continuity of Care, C-CDA CCD

--- a/Documents/Care Plan/Readme.md
+++ b/Documents/Care Plan/Readme.md
@@ -1,31 +1,31 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Care Plan (V2) 2.16.840.1.113883.10.20.22.1.15:2015-08-01 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Care Plan (V2) document template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Care Plan
 

--- a/Documents/Consultation Note/Readme.md
+++ b/Documents/Consultation Note/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Consultation Note (V2) 2.16.840.1.113883.10.20.22.1.4:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Consultation Note

--- a/Documents/Diagnostic Imaging Report/Readme.md
+++ b/Documents/Diagnostic Imaging Report/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Diagnostic Imaging Report (V2) 2.16.840.1.113883.10.20.22.1.5:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Diagnostic Imaging Report

--- a/Documents/Discharge Summary/Readme.md
+++ b/Documents/Discharge Summary/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Discharge Summary (V2) 2.16.840.1.113883.10.20.22.1.8:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Discharge Summary

--- a/Documents/History and Physical/Readme.md
+++ b/Documents/History and Physical/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * History and Physical (V2) 2.16.840.1.113883.10.20.22.1.3:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA History and Physical

--- a/Documents/Operative Note/Readme.md
+++ b/Documents/Operative Note/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Operative Note (V2) 2.16.840.1.113883.10.20.22.1.7:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Operative Note

--- a/Documents/Procedure Note/Readme.md
+++ b/Documents/Procedure Note/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Procedure Note (V2) 2.16.840.1.113883.10.20.22.1.6:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Procedure Note

--- a/Documents/Progress Note/Readme.md
+++ b/Documents/Progress Note/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Progress Note (V2) 2.16.840.1.113883.10.20.22.1.9:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Progress Note

--- a/Documents/Referral Note/Readme.md
+++ b/Documents/Referral Note/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Referral Note (V2) 2.16.840.1.113883.10.20.22.1.14:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Referral Note

--- a/Documents/Transfer Summary/Readme.md
+++ b/Documents/Transfer Summary/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Transfer Summary (V2) 2.16.840.1.113883.10.20.22.1.13:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Continuity of Care Document (CCD) (V2) template.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Transfer Summary

--- a/Encounters/Hospital Discharge Encounter with Billable Diagnoses/Readme.md
+++ b/Encounters/Hospital Discharge Encounter with Billable Diagnoses/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/18/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.22.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.49:2015-08-01
@@ -15,32 +15,32 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Encounter in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a hospitalization with discharge diagnoses. Meaningful Use requires a place to document encounter diagnoses, and this example attempts to satisfy. This example aligns with QRDA suggestion for encounter diagnosis.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Hospital Encounter, Discharge Diagnoses, participant, performer
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/3234327a1a0d4fe4909634591cdfc12b46f0f95d](http://cdasearch.hl7.org/examples/view/3234327a1a0d4fe4909634591cdfc12b46f0f95d)
 
-###Links
+### Links
 
 * [Hospital Discharge Encounter with Billable Diagnoses(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Encounters/Hospital%20Discharge%20Encounter%20with%20Billable%20Diagnoses/Hospital%20Discharge%20Encounter%20with%20Billable%20Diagnoses%28C-CDA2.1%29.xml)

--- a/Encounters/Inpatient Encounter Discharged to Rehab Location/Readme.md
+++ b/Encounters/Inpatient Encounter Discharged to Rehab Location/Readme.md
@@ -1,44 +1,44 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/17/2016
 * SDWG: 2/2/2016
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.22.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.49:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.32
 * 2.16.840.1.113883.10.20.22.4.119:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Encounter in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a hospitalization with discharge disposition. The Discharge Disposition includes both the standard code and a local code, and a discharge destination
 
-###Custodian
+### Custodian
 
 * Lisa Nelson (GitHub: lisarnelson)
 
 
 
-###Keywords
+### Keywords
 
 * Hospital discharge disposition, local code
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4e2426c81bb6d72e62220be171df968dbe7efca5](http://cdasearch.hl7.org/examples/view/4e2426c81bb6d72e62220be171df968dbe7efca5)
 
-###Links
+### Links
 
 * [Inpatient_Encounter_Discharged_to_Rehab_Location(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Encounters/Inpatient%20Encounter%20Discharged%20to%20Rehab%20Location/Inpatient_Encounter_Discharged_to_Rehab_Location%28C-CDA2.1%29.xml)

--- a/Encounters/Multiple CPT E&M Codes/Readme.md
+++ b/Encounters/Multiple CPT E&M Codes/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 9/28/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.22:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.22
@@ -15,34 +15,34 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.4
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Encounter in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to record multiple CPT Evaluation and Management codes with a single encounter.
 
-###Custodian
+### Custodian
 
 * Fred Harmon (Fred.Harmon@greenwayhealth.com)
 
 
-###Keywords
+### Keywords
 
 * Encounter, E&M, CPT codes
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b3a03f02cc01f665c2003](http://cdasearch.hl7.org/examples/view/5a0b3a03f02cc01f665c2003)
 
-###Links
+### Links
 
 * [Multiple CPT E&M Codes Single Encounter(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Encounters/Multiple%20CPT%20E%26M%20Codes/Multiple%20CPT%20E%26M%20Codes%20Single%20Encounter%28C-CDAR2.1%29.xml)

--- a/Encounters/Outpatient Encounter Patient Disenrolled/Readme.md
+++ b/Encounters/Outpatient Encounter Patient Disenrolled/Readme.md
@@ -1,44 +1,44 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/17/2016
 * SDWG: 2/2/2016
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.22.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.49:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.32
 * 2.16.840.1.113883.10.20.22.4.119:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Encounter in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of an outpatient visit discharge disposition. In order to support a local Discharge Disposition code the dischargeDisposition contains the "OTH" nullFlavor.
 
-###Custodian
+### Custodian
 
 * Lisa Nelson (GitHub: lisarnelson)
 
 
 
-###Keywords
+### Keywords
 
 * Outpatient discharge disposition, local code, nullFlavor
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/0358fc1a4bbe08d617113988efb1bfc873f8f1aa](http://cdasearch.hl7.org/examples/view/0358fc1a4bbe08d617113988efb1bfc873f8f1aa)
 
-###Links
+### Links
 
 * [Outpatient Encounter Patient Disenrolled(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Encounters/Outpatient%20Encounter%20Patient%20Disenrolled/Outpatient%20Encounter%20Patient%20Disenrolled%28C-CDA2.1%29.xml)

--- a/Encounters/Outpatient Encounter with Diagnoses/Readme.md
+++ b/Encounters/Outpatient Encounter with Diagnoses/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 * Approval Status: Approved
 * Example Task Force: 5/7/2015
 * SDWG: 5/28/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.22.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.49:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.32
@@ -12,34 +12,34 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.6
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Encounter in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure Encounter Diagnosis for the 170.314(b)(2) Transitions of care - L) Encounter Diagnosis
 
-###Custodian
+### Custodian
 
 * Lisa Nelson (GitHub: lisarnelson)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * Outpatient Visit, Encounter Diagnoses, performer, visit location
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/b45996a0828df13d805e978e6a57f4d509354641](http://cdasearch.hl7.org/examples/view/b45996a0828df13d805e978e6a57f4d509354641)
 
-###Links
+### Links
 
 * [Outpatient Encounter with Diagnoses(C-CDA R2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Encounters/Outpatient%20Encounter%20with%20Diagnoses/Outpatient%20Encounter%20with%20Diagnoses%28C-CDA%20R2.1%29.xml)

--- a/Encounters/Readme.md
+++ b/Encounters/Readme.md
@@ -1,1 +1,1 @@
-##Encounter Section Examples from C-CDA 
+## Encounter Section Examples from C-CDA 

--- a/Family History/Family History Generic/Readme.md
+++ b/Family History/Family History Generic/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/12/2015
@@ -6,35 +6,35 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Family History Organizer (2.16.840.1.113883.10.20.22.4.45 2015-08-01)
 * Family History Observation (2.16.840.1.113883.10.20.22.4.46 2015-08-01)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Family history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * Example shows generic "family history of x" and "no family history of x" with commentary suggesting better options.
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub: benjaminflessner)
-###Keywords
+### Keywords
 
 * Family History
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/f2debf5f44979854a710367c7b2c9c9f2911f4ea](http://cdasearch.hl7.org/examples/view/f2debf5f44979854a710367c7b2c9c9f2911f4ea)
 
-###Links
+### Links
 
 * [Family History generic(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Family%20History/Family%20History%20Generic/Family%20History%20generic%28C-CDA2.1%29.xml)

--- a/Family History/Family History two individuals same relationship to the patient/Readme.md
+++ b/Family History/Family History two individuals same relationship to the patient/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/12/2015
@@ -6,34 +6,34 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Family History Organizer (2.16.840.1.113883.10.20.22.4.45 2015-08-01)
 * Family History Observation (2.16.840.1.113883.10.20.22.4.46 2015-08-01)
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Family history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * Example shows two brothers with multiple conditions. Though they have the same relationship to the patient, they can be identified by their separation into two family history organizers as well as by their subject ID's.
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub: benjaminflessner)
-###Keywords
+### Keywords
 
 * Family History
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/2108b07b1bc891832ce374f956a226422636ee0d](http://cdasearch.hl7.org/examples/view/2108b07b1bc891832ce374f956a226422636ee0d)
 
-###Links
+### Links
 
 * [Family History two individuals same relationship to the patient(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Family%20History/Family%20History%20two%20individuals%20same%20relationship%20to%20the%20patient/Family%20History%20two%20individuals%20same%20relationship%20to%20the%20patient%28C-CDA2.1%29.xml)

--- a/Family History/Normal Family History Father deceased-Mother alive/Readme.md
+++ b/Family History/Normal Family History Father deceased-Mother alive/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 1/15/2015
@@ -6,35 +6,35 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Family History Organizer (2.16.840.1.113883.10.20.22.4.45 2015-08-01)
 * Family History Observation (2.16.840.1.113883.10.20.22.4.46 2015-08-01)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Family history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * Example shows multiple observations for one family member, identifying the cause of death, and a family member with no known problems.
-###Custodian
+### Custodian
 
 *  Benjamin Flessner (GitHub: benjaminflessner)
-###Keywords
+### Keywords
 
 * Family History
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/75fa257530a0a4f050c2f7267342521e66473187](http://cdasearch.hl7.org/examples/view/75fa257530a0a4f050c2f7267342521e66473187)
 
-###Links
+### Links
 
 * [Normal Family History Father deceased Mother alive(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Family%20History/Normal%20Family%20History%20Father%20deceased-Mother%20alive/Normal%20Family%20History%20Father%20deceased%20Mother%20alive%28C-CDA2.1%29.xml)

--- a/Family History/Readme.md
+++ b/Family History/Readme.md
@@ -1,1 +1,1 @@
-##Family History Section Examples from C-CDA 
+## Family History Section Examples from C-CDA 

--- a/Functional Status/Functional Impairment/Readme.md
+++ b/Functional Status/Functional Impairment/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/15/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Functional Status Section 2.16.840.1.113883.10.20.22.2.14 and 2.16.840.1.113883.10.20.22.2.14:2014-06-09
 * Functional Status Result Observation 2.16.840.1.113883.10.20.22.4.67 and 2.16.840.1.113883.10.20.22.4.67:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Functional Status in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a functional impairment. It only illustrates one potential templated within the functional status section and was originally prepared for the ONC 2014 Transitions of Care test scenario, inpatient for MU2 170.314(b)(2). Note that there are significant changes to functional and cognitive status in C-CDA 2.1 (including section breakout and deprecation of certain templates). This example represents the proper way to send a functional impairment in C-CDA R2.1.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) and John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * impairment
 
@@ -34,11 +34,11 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/2c61153be9d4530a94ec7bad0390ab6bbe48d3db](http://cdasearch.hl7.org/examples/view/2c61153be9d4530a94ec7bad0390ab6bbe48d3db)
 
 
-###Links
+### Links
 
 * [Functional Impairment Dependent on Walking Stick (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Functional%20Status/Functional%20Impairment/Functional%20Impairment%20Dependent%20on%20Walking%20Stick%20%28C-CDAR2.1%29.xml)

--- a/Functional Status/No Functional Impairment/Readme.md
+++ b/Functional Status/No Functional Impairment/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/18/2015, 6/15/2017
 * SDWG: 7/9/2015
 * SDWG C-CDA R2.1 Upgrade: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Functional Status Section 2.16.840.1.113883.10.20.22.2.14 and 2.16.840.1.113883.10.20.22.2.14:2014-06-09
 * Functional Status Result Observation 2.16.840.1.113883.10.20.22.4.67 and 2.16.840.1.113883.10.20.22.4.67:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Functional Status in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no functional impairment. It only illustrates one potential templated within the functional status section and was originally prepared for the ONC 2014 170.314(b)(2) Transitions of care - M) Functional and Cognitive Status. Note that there are significant changes to functional and cognitive status in C-CDA 2.1 (including section breakout and deprecation of certain templates). This example represents the proper way to send no functional impairment in C-CDA R2.1.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) and John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * no impairment
 
@@ -35,11 +35,11 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/bb8003ab201395f3041d745a58490291bb3c2057](http://cdasearch.hl7.org/examples/view/bb8003ab201395f3041d745a58490291bb3c2057)
 
 
-###Links
+### Links
 
 * [No Functional Impairment (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Functional%20Status/No%20Functional%20Impairment/No%20Functional%20Impairment%20%28C-CDAR2.1%29.xml)

--- a/Functional Status/Readme.md
+++ b/Functional Status/Readme.md
@@ -1,1 +1,1 @@
-##Functional Status Section Examples from C-CDA 
+## Functional Status Section Examples from C-CDA 

--- a/General/External Document Reference/readme.md
+++ b/General/External Document Reference/readme.md
@@ -1,10 +1,10 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 7/13/2017
 * SDWG: 10/5/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
 
 * Problem Section: 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
@@ -15,27 +15,27 @@
 
 Reference to full CDA sample: PROBLEMS_in_Empty_C-CDA_2.1 (in git repo at same location as this snippet)
 
-###Validation location
-* https://sitenv.org/sandbox-ccda/ccda-validator
+### Validation location
+* https://site.healthit.gov/sandbox-ccda/ccda-validator
 
-###Comments
+### Comments
 
 * This demonstrates how an individual entry may refer to an external document where information was originally provided (e.g. a problem in this example). In addition, how to also link back to the original observation using externalObservation is also shown. While these elements are optional, they help create a chain of data provenance.
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 * externalDocument, externalObservation, reference
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d65](http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d65)
 
-###Links
+### Links
 
 * [PROBLEMS_in_Empty_C-CDA_2.1 (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/External%20Document%20Reference/PROBLEMS_in_Empty_C-CDA_2.1%20%28C-CDAR2.1%29.xml)
 * [External Document Reference QRDA Template (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/External%20Document%20Reference/External%20Document%20Reference%20QRDA%20Template%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Act/Readme.md
+++ b/General/Narrative Reference - Act/Readme.md
@@ -1,35 +1,35 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/595166aad2b38b3ad3157d66](http://cdasearch.hl7.org/examples/view/595166aad2b38b3ad3157d66)
 
-###Links
+### Links
 
 * [Act text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Act/Act%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Encounter/Readme.md
+++ b/General/Narrative Reference - Encounter/Readme.md
@@ -1,34 +1,34 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/d1ffa6a994d551b91ad0532807777fd735a158de](http://cdasearch.hl7.org/examples/view/d1ffa6a994d551b91ad0532807777fd735a158de)
 
-###Links
+### Links
 
 * [Encounter text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Encounter/Encounter%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Observation/Readme.md
+++ b/General/Narrative Reference - Observation/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/44d5190e0b8acb77c11e2ebd31450dcdac872c65](http://cdasearch.hl7.org/examples/view/44d5190e0b8acb77c11e2ebd31450dcdac872c65)
 
-###Links
+### Links
 
 * [Observation text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Observation/Observation%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Organizer/Readme.md
+++ b/General/Narrative Reference - Organizer/Readme.md
@@ -1,35 +1,35 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/0a8f0ac3890c21130eb539e0b256d6d505c0a17e](http://cdasearch.hl7.org/examples/view/0a8f0ac3890c21130eb539e0b256d6d505c0a17e)
 
-###Links
+### Links
 
 * [Organizer text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Organizer/Organizer%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Procedure/Readme.md
+++ b/General/Narrative Reference - Procedure/Readme.md
@@ -1,25 +1,25 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
@@ -27,10 +27,10 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5535d4fa945c1551f1cb92dc6049163fe8a817b8](http://cdasearch.hl7.org/examples/view/5535d4fa945c1551f1cb92dc6049163fe8a817b8)
 
-###Links
+### Links
 
 * [Procedure text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Procedure/Procedure%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - SubstanceAdministration/Readme.md
+++ b/General/Narrative Reference - SubstanceAdministration/Readme.md
@@ -1,35 +1,35 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/0a8f0ac3890c21130eb539e0b256d6d505c0a17e](http://cdasearch.hl7.org/examples/view/0a8f0ac3890c21130eb539e0b256d6d505c0a17e)
 
-###Links
+### Links
 
 * [SubstanceAdministration text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20SubstanceAdministration/SubstanceAdministration%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative Reference - Supply/Readme.md
+++ b/General/Narrative Reference - Supply/Readme.md
@@ -1,25 +1,25 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/1/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Applies to all C-CDA/CDA templates with this entry type
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This sample will not validate
 
-###Validation location
+### Validation location
 * Not applicable
 
-###Comments
+### Comments
 * This example demonstrates how to link the section narrative (section.text) to the coded information (entry) below. The example includes several comments and does not conform to any specific C-CDA/CDA template. The principles agreed to in this sample should be present in all other examples.
 
-###Custodian
+### Custodian
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) (original design courtesy of George Cole)
 
-###Keywords
+### Keywords
 
 * narrative, narrative-entry, linking text
 
@@ -29,10 +29,10 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/595166aad2b38b3ad3157d67](http://cdasearch.hl7.org/examples/view/595166aad2b38b3ad3157d67)
 
-###Links
+### Links
 
 * [Supply text and originalText references (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Narrative%20Reference%20-%20Supply/Supply%20text%20and%20originalText%20references%20%28C-CDAR2.1%29.xml)

--- a/General/Narrative in CDA Documents/Readme.md
+++ b/General/Narrative in CDA Documents/Readme.md
@@ -1,34 +1,34 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 10/19/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * N/A
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * N/A
 
-###Validation location
+### Validation location
 * N/A
 
-###Comments
+### Comments
 * This is a reference to a google document summarizing guidance for [narrative in CDA Documents](https://docs.google.com/document/d/1r1qBuzPQNkLiNpLkTOIv4RHXQHkyx7_N7_Es3MiHUek/edit)
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 * Lisa Nelson
 
-###Keywords
+### Keywords
 
 * narrative entry linking, anchors
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b3a01f02cc01f665c2001](http://cdasearch.hl7.org/examples/view/5a0b3a01f02cc01f665c2001)

--- a/General/No Section Information Problems/Readme.md
+++ b/General/No Section Information Problems/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 1/30/2014
@@ -6,41 +6,41 @@
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 :
 
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no information available for problems.
 
-###Certification
+### Certification
 
 * ONC
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * null section, no information section
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4625469228fa0758500a4a62afb17f585412e50b](http://cdasearch.hl7.org/examples/view/4625469228fa0758500a4a62afb17f585412e50b)
 
-###Links
+### Links
 
 * [No Information Problems(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/No%20Section%20Information%20Problems/No%20Information%20Problems%28C-CDA2.1%29.xml)

--- a/General/Parent Document Replace Relationship/Readme.md
+++ b/General/Parent Document Replace Relationship/Readme.md
@@ -1,34 +1,34 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/4/2017
 * SDWG: 5/18/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.1.
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a complete document for validation
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator) on 5/4/2017
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator) on 5/4/2017
 
-###Comments
+### Comments
 * This is an example of how a continuity of care document (or other document) may reference parent documents. This one replaces a previous document.
 
-###Custodian
+### Custodian
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * parentDocument, relatedDocument, CCD
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/74b808147151e634cbe09eaee3dd9f6f5d786317](http://cdasearch.hl7.org/examples/view/74b808147151e634cbe09eaee3dd9f6f5d786317)
 
-###Links
+### Links
 
 * [CCD Parent Document Replace (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/General/Parent%20Document%20Replace%20Relationship/CCD%20Parent%20Document%20Replace%20%28C-CDAR2.1%29.xml)

--- a/General/Readme.md
+++ b/General/Readme.md
@@ -1,1 +1,1 @@
-##General Examples from C-CDA 
+## General Examples from C-CDA 

--- a/General/effectiveTime in CDA Documents/Readme.md
+++ b/General/effectiveTime in CDA Documents/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 10/19/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * N/A
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * N/A
 
-###Validation location
+### Validation location
 * N/A
 
-###Comments
+### Comments
 * This is a reference to a google document summarizing guidance for [effectiveTime use in CDA Documents](https://docs.google.com/document/d/158utf0owdWLGwarP3Zgf6FCSfDMKZwIjUSmFb7_sslc/edit)
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * nullFlavor, value, low, high, center, width, period, UNK, NI, timezone, offset
 
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b3a01f02cc01f665c2002](http://cdasearch.hl7.org/examples/view/5a0b3a01f02cc01f665c2002)

--- a/Goals/Goals Narrative Only/Readme.md
+++ b/Goals/Goals Narrative Only/Readme.md
@@ -1,41 +1,41 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/4/2016
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.60
 * 2.16.840.1.113883.10.20.22.4.121
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how to send a goals section with only narrative.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * narrative-only
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/dd3cf25f7cb99b24354039d7a7fea3fec23621fb](http://cdasearch.hl7.org/examples/view/dd3cf25f7cb99b24354039d7a7fea3fec23621fb)
 
-###Links
+### Links
 
 * [Goals Narrative Only(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Goals/Goals%20Narrative%20Only/Goals%20Narrative%20Only%28C-CDA2.1%29.xml)

--- a/Goals/Readme.md
+++ b/Goals/Readme.md
@@ -1,1 +1,1 @@
-##Goals Section Examples from C-CDA 
+## Goals Section Examples from C-CDA 

--- a/Header/Care Team In Transition of Care Documents/Readme.md
+++ b/Header/Care Team In Transition of Care Documents/Readme.md
@@ -1,37 +1,37 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/22/2016
 * SDWG: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * serviceEvent and Performer
 * N/A
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+### Validation location
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 * This is an example of how to include Care Team information for 170.315_b1 Ambulatory test data
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 * George Cole
 
-###Keywords
+### Keywords
 * Care Team, transition of care test data
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4e1047540ebbd74205b20a81bed34143f4d4b3fa](http://cdasearch.hl7.org/examples/view/4e1047540ebbd74205b20a81bed34143f4d4b3fa)
 
-###Links
+### Links
 
 * [Care Team In Transition of Care Documents(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Header/Care%20Team%20In%20Transition%20of%20Care%20Documents/Care%20Team%20In%20Transition%20of%20Care%20Documents%28C-CDA2.1%29.xml)

--- a/Header/Direct Address/Readme.md
+++ b/Header/Direct Address/Readme.md
@@ -4,15 +4,15 @@
 * Example Task Force: 11/2/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.1.1:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Representation of Direct Trust Addresses for Patients and Covered Entities
 
 
 ### Validation location
-* https://sitenv.org/sandbox-ccda/ccda-validator
+* https://site.healthit.gov/sandbox-ccda/ccda-validator
 
 ### Comments
 * This demonstrates a patient with a Patient DirectTrust Address and a Provider Organization with a Covered Entity DirectTrust Address.
@@ -25,10 +25,10 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b3a05f02cc01f665c2004](http://cdasearch.hl7.org/examples/view/5a0b3a05f02cc01f665c2004)
 
-###Links
+### Links
 
 * [Patient and Provider Organization Direct Address(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Header/Direct%20Address/Patient%20and%20Provider%20Organization%20Direct%20Address%28C-CDAR2.1%29.xml)

--- a/Header/Multiple Patient Identifiers/readme.md
+++ b/Header/Multiple Patient Identifiers/readme.md
@@ -4,16 +4,16 @@
 * Example Task Force: 7/27/2017
 * SDWG: 10/5/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.1.1:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
 
 ### Validation location
-* https://sitenv.org/sandbox-ccda/ccda-validator
+* https://site.healthit.gov/sandbox-ccda/ccda-validator
 
 ### Comments
 * This demonstrates a patient with multiple identifiers from different institutions.
@@ -26,10 +26,10 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d67](http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d67)
 
-###Links
+### Links
 
 * [Multiple Patient Identifiers (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Header/Multiple%20Patient%20Identifiers/Multiple%20Patient%20Identifiers%20%28C-CDAR2.1%29.xml)

--- a/Header/Patient Deceased/Readme.md
+++ b/Header/Patient Deceased/Readme.md
@@ -1,36 +1,36 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/19/2018
 * SDWG: 6/27/2019
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * US Realm Header: 2.16.840.1.113883.10.20.22.1.1:2015-08-01
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to use sdtc extension of deceasedInd. See this site for more on CDA extensions: http://wiki.hl7.org/index.php?title=CDA_R2_Extensions
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * deceasedInd,deceasedTime
 

--- a/Header/Patient Demographic Information/Readme.md
+++ b/Header/Patient Demographic Information/Readme.md
@@ -1,48 +1,49 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 9/24/2015
-* SDWG: 10/15/2015
+
+* SDWG: 10/15/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * recordTarget
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure Patient Demographics for the 170.314(b)(2) Transitions of care - A) Patient Demographics.
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
 
-###Keywords
+### Keywords
 
 * Demographics, Name, Address, Telecom, Phone, Email, Race, Ethnicity, Religious Affiliation, Marital Status, Language
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/de1f429a35879e80f3df21b5fb1522809fcdb736](http://cdasearch.hl7.org/examples/view/de1f429a35879e80f3df21b5fb1522809fcdb736)
 
-###Links
+### Links
 
 * [Patient Demographic Information(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Header/Patient%20Demographic%20Information/Patient%20Demographic%20Information%28C-CDA2.1%29.xml)

--- a/Header/Patient Previous Name/Readme.md
+++ b/Header/Patient Previous Name/Readme.md
@@ -1,46 +1,47 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/7/2016
-* SDWG: 7/7/2016
+
+* SDWG: 7/7/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * recordTarget
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 * Other required elements are omitted so several errors will be present if inserted without adding other information (e.g. telecom, address)
 
-###Comments
+### Comments
 
 * This example illustrates how to structure Patient's previous name.
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * Demographics, Name, Prior Name, Previous Name, Birth Name
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/951b8a84a17516ca8ac07401ef0132dbc8b9d003](http://cdasearch.hl7.org/examples/view/951b8a84a17516ca8ac07401ef0132dbc8b9d003)
 
-###Links
+### Links
 
 * [Patient Previous Name(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Header/Patient%20Previous%20Name/Patient%20Previous%20Name%28C-CDA2.1%29.xml)

--- a/Header/Patient With Prior Addresses/Readme.md
+++ b/Header/Patient With Prior Addresses/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status
+## Approval Status
 
 
 * Approval Status: Approved
@@ -6,7 +6,7 @@
 
 * SDWG: 10/1/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * recordTarget/PatientRole/addr[2]
@@ -15,35 +15,35 @@
 
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 
 * N/A
 
 
 
-###Validation 
+### Validation 
 * location
 
-* https://sitenv.org/sandbox-ccda/ccda-validator
+* https://site.healthit.gov/sandbox-ccda/ccda-validator
 
 
 
-###Comments
+### Comments
 
 
 * This example illustrates how to structure multiple past addresses for a patient
 
 
 
-###Custodian
+### Custodian
 
 
 * Ed Donaldson, donaldson.ed@gmail.com (GitHub: donaldson-ed) 
 
 
 
-###Keywords
+### Keywords
 
 * 
 Demographics

--- a/Header/Readme.md
+++ b/Header/Readme.md
@@ -1,3 +1,3 @@
-##C-CDA Header Examples
+## C-CDA Header Examples
 
  

--- a/Health Concerns/Health Concerns Link to Problems Section with linkHTML/Readme.md
+++ b/Health Concerns/Health Concerns Link to Problems Section with linkHTML/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/15/15
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.58:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.132:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
@@ -13,34 +13,34 @@
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.3:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to link a concern to a problem in the problem list section with linkHTML.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * linkHTML, entry reference
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/57b4a46c570caf4e2f83342b32b64bc1725f0834](http://cdasearch.hl7.org/examples/view/57b4a46c570caf4e2f83342b32b64bc1725f0834)
 
-###Links
+### Links
 
 * [Health Concerns Link to Problems Section with linkHTML(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Health%20Concerns/Health%20Concerns%20Link%20to%20Problems%20Section%20with%20linkHTML/Health%20Concerns%20Link%20to%20Problems%20Section%20with%20linkHTML%28C-CDA2.1%29.xml)

--- a/Health Concerns/Health Concerns Link to Problems Section/Readme.md
+++ b/Health Concerns/Health Concerns Link to Problems Section/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/15/2015
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.58:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.132:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
@@ -13,34 +13,34 @@
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.3:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to link a concern to a problem in the problem list section.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * entry reference
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/d3dd83ecc6e5130f838d7107761a81db24aa3f35](http://cdasearch.hl7.org/examples/view/d3dd83ecc6e5130f838d7107761a81db24aa3f35)
 
-###Links
+### Links
 
 * [Health Concerns Link to Problems Section(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Health%20Concerns/Health%20Concerns%20Link%20to%20Problems%20Section/Health%20Concerns%20Link%20to%20Problems%20Section%28C-CDA2.1%29.xml)

--- a/Health Concerns/Health Concerns Narrative Only/Readme.md
+++ b/Health Concerns/Health Concerns Narrative Only/Readme.md
@@ -1,40 +1,40 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 2/4/2016
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.58:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how to send a health concern section with only narrative.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * narrative-only
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/742456c583d5c94cda3bb91966209dd98bcee41e](http://cdasearch.hl7.org/examples/view/742456c583d5c94cda3bb91966209dd98bcee41e)
 
-###Links
+### Links
 
 * [Health Concerns Narrative Only(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Health%20Concerns/Health%20Concerns%20Narrative%20Only/Health%20Concerns%20Narrative%20Only%28C-CDA2.1%29.xml)

--- a/Health Concerns/No Known Health Concerns/Readme.md
+++ b/Health Concerns/No Known Health Concerns/Readme.md
@@ -1,37 +1,37 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 11/5/2015
 * SDWG: 11/12/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.58:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.132:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how an author can record they have no health concerns for a patient.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * no known
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/eadf624ca7fa2754a77d8023f26d0576ba70041f](http://cdasearch.hl7.org/examples/view/eadf624ca7fa2754a77d8023f26d0576ba70041f)
 
-###Links
+### Links
 
 * [No Known Health Concerns(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Health%20Concerns/No%20Known%20Health%20Concerns/No%20Known%20Health%20Concerns%28C-CDA2.1%29.xml)

--- a/Health Concerns/Readme.md
+++ b/Health Concerns/Readme.md
@@ -1,1 +1,1 @@
-##Health Concerns Section Examples from C-CDA 
+## Health Concerns Section Examples from C-CDA 

--- a/Immunizations/Immunization not given Patient refused/Readme.md
+++ b/Immunizations/Immunization not given Patient refused/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 10/29/2015
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
 
@@ -15,29 +15,29 @@
 * Immunization Activity 2.16.840.1.113883.10.20.22.4.52:2015-08-01
 
 * 2.16.840.1.113883.10.20.22.4.54:2014-06-09
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Immunizations in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how an author can record a patient refused an immunization.
-###Custodian
+### Custodian
 
 *  Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * substance, immunzation
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/8afc26db2966f01c1c065075e44031d29a865414](http://cdasearch.hl7.org/examples/view/8afc26db2966f01c1c065075e44031d29a865414)
 
-###Links
+### Links
 
 * [Immunization not given Patient refused(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Immunizations/Immunization%20not%20given%20Patient%20refused/Immunization%20not%20given%20Patient%20refused%28C-CDA2.1%29.xml)

--- a/Immunizations/Influenza Vaccination with NDC/Readme.md
+++ b/Immunizations/Influenza Vaccination with NDC/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 9/6/2018
 * SDWG: 10/1/2018
 
 
-###C-CDA 2.1 Example: 
+### C-CDA 2.1 Example: 
 
 
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
@@ -13,22 +13,22 @@
 * Immunization Activity 2.16.840.1.113883.10.20.22.4.52:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.54:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Immunizations in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 * This example illustrates how to structure Immunizations for the 170.314(b)(2) Transitions of care - J) Immunizations with a translation for the NDC code.
 
-###Custodian
+### Custodian
 
 *  Brett Marquard, brett@waveoneassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * substance, immunzation 
 

--- a/Immunizations/Influenza Vaccination/Readme.md
+++ b/Immunizations/Influenza Vaccination/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 4/16/2015
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
@@ -16,29 +16,29 @@
 * Immunization Activity 2.16.840.1.113883.10.20.22.4.52:2015-08-01
 
 * 2.16.840.1.113883.10.20.22.4.54:2014-06-09
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Immunizations in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure Immunizations for the 170.314(b)(2) Transitions of care - J) Immunizations.
-###Custodian
+### Custodian
 
 *  Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * substance, immunzation
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/3c38951895eee8513fb9eb60c7b5dae8060da1d5](http://cdasearch.hl7.org/examples/view/3c38951895eee8513fb9eb60c7b5dae8060da1d5)
 
-###Links
+### Links
 
 * [Influenza Vaccination(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Immunizations/Influenza%20Vaccination/Influenza%20Vaccination%28C-CDA2.1%29.xml)

--- a/Immunizations/No Section Information Immunizations/Readme.md
+++ b/Immunizations/No Section Information Immunizations/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 * Example Task Force: 9/3/2020
@@ -6,35 +6,35 @@
 
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.2
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.2
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Immunizations in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no information available for immunizations. This example is similar to the No Section Information Problems example. This sample is not approriate for asserting 'No Known Immunizations'.
 
-###Certification
+### Certification
 
 * ONC
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * null section, no information section
 

--- a/Immunizations/Readme.md
+++ b/Immunizations/Readme.md
@@ -1,1 +1,1 @@
-##Immunization Section Examples from C-CDA 
+## Immunization Section Examples from C-CDA 

--- a/Immunizations/Unknown Immunization Status/Readme.md
+++ b/Immunizations/Unknown Immunization Status/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/21/2013
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.2:2015-08-01
 
@@ -15,29 +15,29 @@
 * Immunization Activity 2.16.840.1.113883.10.20.22.4.52:2015-08-01
 
 * 2.16.840.1.113883.10.20.22.4.54:2014-06-09
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Immunizations in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how an author can record they do now know whether the patient has received any vaccinations.
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * substance, immunzation
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/e2f451150582d66dc3057170ff4f5ceb164098eb](http://cdasearch.hl7.org/examples/view/e2f451150582d66dc3057170ff4f5ceb164098eb)
 
-###Links
+### Links
 
 * [Unknown Immunization Status(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Immunizations/Unknown%20Immunization%20Status/Unknown%20Immunization%20Status%28C-CDA2.1%29.xml)

--- a/Interventions/Intervention Counseling/Readme.md
+++ b/Interventions/Intervention Counseling/Readme.md
@@ -1,38 +1,38 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/2/2020
 * SDWG: 7/9/2020
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.21.2.3:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.131:2015-08-0
 * 2.16.840.1.113883.10.20.22.4.12:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates an intervention section, with an intervention act wrapping a procedure activity act.
 * The example task force approved this to provide a parallel example to how QRDA communicates interventions. Some systems may choose to include this in the procedure section.
 
 
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@waveoneassociates.com (GitHub: brettmarquard)
 
 
-###Keywords
+### Keywords
 
 * procedure activity act, intervention
 

--- a/Interventions/Readme.md
+++ b/Interventions/Readme.md
@@ -1,1 +1,1 @@
-##Interventions Section Examples from C-CDA 
+## Interventions Section Examples from C-CDA 

--- a/Medical Equipment/Implant UDI Organizer/Readme.md
+++ b/Medical Equipment/Implant UDI Organizer/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status
+## Approval Status
 * Approval Status: Pending
 * Example Task Force: 
 * SDWG: 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.23
 * 2.16.840.1.113883.10.20.22.2.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14
 * 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.37
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to record the full details of a UDI. This examples follows the design in Appendix B of the 2019 C-CDA Companion Guide.
 
-###Custodian
+### Custodian
 
 * Emma Jones
 
-###Keywords
+### Keywords
 
 * UDI, implant, UDI organizer

--- a/Medical Equipment/Implant UDI Unknown/Readme.md
+++ b/Medical Equipment/Implant UDI Unknown/Readme.md
@@ -1,39 +1,39 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/27/2017
 * SDWG: 10/5/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.23
 * 2.16.840.1.113883.10.20.22.2.23:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of a medical equipment section containing an implantable device where the full unique device identifier (UDI) is unknown.
 
-###Custodian
+### Custodian
 
 * May Terry, may@flatiron.com (GitHub: mayterry88)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * multiple implants
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d66](http://cdasearch.hl7.org/examples/view/59ef40cee6e15d000ba47d66)
 
-###Links
+### Links
 
 * [Implant UDI Unknown (C-CDA R2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medical%20Equipment/Implant%20UDI%20Unknown/Implant%20UDI%20Unknown%20%28C-CDA%20R2.1%29.xml)

--- a/Medical Equipment/Implant Without Procedure/Readme.md
+++ b/Medical Equipment/Implant Without Procedure/Readme.md
@@ -1,43 +1,43 @@
-##Approval Status
+## Approval Status
 * Approval Status: Approved
 * Example Task Force: 5/19/2016
 * SDWG: 6/3/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.23
 * 2.16.840.1.113883.10.20.22.2.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14
 * 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.37
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how an author can record an implant when the procedure is unknown.
 
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub: benjaminflessner)
 
 
-###Keywords
+### Keywords
 
 * unknown procedure, UDI, implant
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/bacadc7c7194815ce4fcd741108f96a96a3a97a1](http://cdasearch.hl7.org/examples/view/bacadc7c7194815ce4fcd741108f96a96a3a97a1)
 
-###Links
+### Links
 
 * [Implant Without Procedure(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medical%20Equipment/Implant%20Without%20Procedure/Implant%20Without%20Procedure%28C-CDA2.1%29.xml)

--- a/Medical Equipment/Multiple Implants/Readme.md
+++ b/Medical Equipment/Multiple Implants/Readme.md
@@ -1,40 +1,40 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/4/2016
 * SDWG: 5/18/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.23
 * 2.16.840.1.113883.10.20.22.2.23:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how a single procedure (angioplasty) can have multiple implants (2 drug eluting stents). There are still two entries since this is being included in medical equipment rather than procedure section.
 
-###Custodian
+### Custodian
 
 * John D'Amore, jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Certification
+### Certification
 * ONC
 
-###Keywords
+### Keywords
 
 * multiple implants
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/93ef77b9d74d9d5213bea81f320de15b8b279d8b](http://cdasearch.hl7.org/examples/view/93ef77b9d74d9d5213bea81f320de15b8b279d8b)
 
-###Links
+### Links
 
 * [Multiple Implants (C-CDA R2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medical%20Equipment/Multiple%20Implants/Multiple%20Implants%20%28C-CDA%20R2.1%29.xml)

--- a/Medical Equipment/No Implanted Devices/Readme.md
+++ b/Medical Equipment/No Implanted Devices/Readme.md
@@ -1,43 +1,43 @@
-##Approval Status 
+## Approval Status 
 * Approval Status: Approved
 * Example Task Force: 12/15/2015
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.23
 * 2.16.840.1.113883.10.20.22.2.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14
 * 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.37
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how an author can record a patient has no implanted devices
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
 
-###Keywords
+### Keywords
 
 * UDI, implant
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/258fce77114e797899a59b42c56460c13a3c9a7e](http://cdasearch.hl7.org/examples/view/258fce77114e797899a59b42c56460c13a3c9a7e)
 
-###Links
+### Links
 
 * [No Implanted Devices(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medical%20Equipment/No%20Implanted%20Devices/No%20Implanted%20Devices%28C-CDA2.1%29.xml)

--- a/Medical Equipment/Non-Medicinal Supply - Cane and Eyeglasses/Readme.md
+++ b/Medical Equipment/Non-Medicinal Supply - Cane and Eyeglasses/Readme.md
@@ -1,29 +1,29 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 10/3/2019
 * SDWG: 10/10/2019
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Non-Medicinal Supply Activity (V2): 2.16.840.1.113883.10.20.22.4.50:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 * SITE
 
-###Comments
+### Comments
 * This example demonstrates how to represent equipment supplied to or used by a 
 patient such as wheelchairs, canes, walkers, hearing aids, eye glasses.
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 * Lisa R Nelson lnelson@maxmd.com (GitHub: lisarnelson/C-CDA-Examples
 
-###Keywords
+### Keywords
 * Non-Medicinal Devices; Medical Devices
 
 Permalink

--- a/Medical Equipment/Readme.md
+++ b/Medical Equipment/Readme.md
@@ -1,1 +1,1 @@
-##Medical Equipment Section Examples from C-CDA 
+## Medical Equipment Section Examples from C-CDA 

--- a/Medications/Free Text Medication SIG/Readme.md
+++ b/Medications/Free Text Medication SIG/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/1/2018
 * SDWG: 6/27/2019
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Medications Section: 2.16.840.1.113883.10.20.22.2.1.1:2014-06-09
 * Medication Activity: 2.16.840.1.113883.10.20.22.4.16:2014-06-09
 * Medication Information: 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of having a medication with only a free text SIG when you have no other coded information. 
 
-###Custodian
+### Custodian
 
 * Brett Marquard
 
-###Keywords
+### Keywords
 
 * free text SIG
 

--- a/Medications/Med Relative Dose IV Drug/Readme.md
+++ b/Medications/Med Relative Dose IV Drug/Readme.md
@@ -17,7 +17,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 ### Comments

--- a/Medications/Med at bedtime/Readme.md
+++ b/Medications/Med at bedtime/Readme.md
@@ -1,39 +1,39 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/16/2017
 * SDWG: 5/18/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Medications Section: 2.16.840.1.113883.10.20.22.2.1.1:2014-06-09
 * Medication Activity: 2.16.840.1.113883.10.20.22.4.16:2014-06-09
 * Medication Information: 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of having a medication with event timing (take at bedtime or at the "hour of sleep" (HS))
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * medication, event timing, HS, bedtime
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4214145b869b697ff55e6ae4d55585c338db1c8d](http://cdasearch.hl7.org/examples/view/4214145b869b697ff55e6ae4d55585c338db1c8d)
 
-###Links
+### Links
 
 * [Med at bedtime(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Med%20at%20bedtime/Med%20at%20bedtime%28C-CDAR2.1%29.xml)

--- a/Medications/Med every 4-6 hours/Readme.md
+++ b/Medications/Med every 4-6 hours/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 1/30/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 
@@ -16,32 +16,32 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a medication (Sudafed) which to be administered every 4-6 hours, a common dosing pattern. Representing the range of potential of hours is done through a low and high child element of the period within effectiveTime of PIVL_TS.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * medications, Dose frequency, pre-coordinated medication
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4f3c542cfceda966aee61e29528f895cb8024602](http://cdasearch.hl7.org/examples/view/4f3c542cfceda966aee61e29528f895cb8024602)
 
-###Links
+### Links
 
 * [Med every 4-6 hours(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Med%20every%204-6%20hours/Med%20every%204-6%20hours%28C-CDA2.1%29.xml)

--- a/Medications/Med oral QID with PRN/Readme.md
+++ b/Medications/Med oral QID with PRN/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 1/9/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
@@ -17,31 +17,31 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a medication which is QID and PRN (as needed) but with no precondition specified. It was generated based on SDWG list-serv discussion in December 2013. It also demonstrated a pre-coordinated generic medication coded at the SDC level (generic 600mg Oral Tablet) in RxNorm hierarchy.
 
-###Custodian
+### Custodian
 
 * Brett Marquard
 * 
-###Keywords
+### Keywords
 
 * medications
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/26db7c4228f4f13bcaefbe776df4e3eac58e31b7](http://cdasearch.hl7.org/examples/view/26db7c4228f4f13bcaefbe776df4e3eac58e31b7)
 
-###Links
+### Links
 
 * [Med oral QID with PRN(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Med%20oral%20QID%20with%20PRN/Med%20oral%20QID%20with%20PRN%28C-CDA2.1%29.xml)

--- a/Medications/Med oral liquid PRN/Readme.md
+++ b/Medications/Med oral liquid PRN/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/5/2018
 * SDWG: 6/27/2019
  
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.2.1.1:2014-06-09
@@ -14,24 +14,24 @@
 * 2.16.840.1.113883.10.20.22.4.25
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a liquid medicaiotn PRN (as needed) with a cough precondition specified.  
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@waveoneassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * medications
 

--- a/Medications/Med oral with indications and instructions/Readme.md
+++ b/Medications/Med oral with indications and instructions/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/15/2016
 * SDWG: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 
@@ -14,30 +14,30 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a medication administered orally with a PRN coded precondition, instructions (not PRN), and indications (not PRN).
 
-###Custodian
+### Custodian
 
 * George Cole
-###Keywords
+### Keywords
 
 * medications
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/df6a37361daf6195d0dd9844032445e4c442bbc8](http://cdasearch.hl7.org/examples/view/df6a37361daf6195d0dd9844032445e4c442bbc8)
 
-###Links
+### Links
 
 * [Med oral with indications and instructions(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Med%20oral%20with%20indications%20and%20instructions/Med%20oral%20with%20indications%20and%20instructions%28C-CDA2.1%29.xml)

--- a/Medications/Medication Frequency Patterns/Readme.md
+++ b/Medications/Medication Frequency Patterns/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force:
@@ -6,27 +6,27 @@
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * N/A
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * N/A
 
-###Validation location
+### Validation location
 * N/A
 
-###Comments
+### Comments
 * This is a reference to a google document of [common medication frequency patterns](https://docs.google.com/document/d/1Y0Z458o_MrR2aPnpx6EygO6hpI88Bl95esjRWZ0agtY/edit)
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * medication frequencies, bid, two times daily, q12h, every 12 hours, tid, three times daily, q8h, every 8 hours, qid, four times daily, q6h, every 6 hours, qd, daily, q24h, every 24 hours, qod, every other day, qm, Once a month, Every other week, 1 hour after meal, before dinner, before lunch (from lat. ante cibus diurnus)
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/9588687865c0f945a326364a9449321690c7a7ef](http://cdasearch.hl7.org/examples/view/9588687865c0f945a326364a9449321690c7a7ef)

--- a/Medications/Medication Refused/Readme.md
+++ b/Medications/Medication Refused/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 5/3/2018
 * SDWG: 12/6/2018
 
-##Templates
+## Templates
 
 * Medications Section: 2.16.840.1.113883.10.20.22.2.1.1:2014-06-09
 * Medication Activity: 2.16.840.1.113883.10.20.22.4.16:2014-06-09
 * Medication Information: 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 
-##Validation location:
+## Validation location:
 
 TBD
 
 Reference to full CDA sample: TBD
 
-##Comments
+## Comments
 
 * This is an example of a patient refusing to take a medication at a point in time due to a reason of patient objection (QRDA template used)
 
-##Custodian
+## Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-##Keywords
+## Keywords
 
 * medication, negation
 

--- a/Medications/Medication statusCodes/Readme.md
+++ b/Medications/Medication statusCodes/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force:
@@ -6,27 +6,27 @@
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * N/A
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * N/A
 
-###Validation location
+### Validation location
 * N/A
 
-###Comments
+### Comments
 * This is a reference to a google document of [medication statusCodes](https://docs.google.com/spreadsheets/d/1d0RJoyzVQISK4ai3zbjKT6PCuOEQzgWBCqarDHyD-JE/edit). SDWG developed this with the Pharmacy WG.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * medication status
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4280301bd364949698a3d784af74885f85e67886](http://cdasearch.hl7.org/examples/view/4280301bd364949698a3d784af74885f85e67886)

--- a/Medications/No Medications/Readme.md
+++ b/Medications/No Medications/Readme.md
@@ -1,37 +1,37 @@
-##Approval Status 
+## Approval Status 
 * Approval Status: Approved
 * Example Task Force: 3/13/2014
 * SDWG: 4/10/2014
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.2.1.1:2014-06-09
 * Medication Activity 2.16.840.1.113883.10.20.22.4.16:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 * This is an example of no medications
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * medications
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4a9475e3e90806627d1c84763ef785b94eca9fd8](http://cdasearch.hl7.org/examples/view/4a9475e3e90806627d1c84763ef785b94eca9fd8)
 
-###Links
+### Links
 
 * [No Medications(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/No%20Medications/No%20Medications%28C-CDA2.1%29.xml)

--- a/Medications/Readme.md
+++ b/Medications/Readme.md
@@ -1,3 +1,3 @@
-##Medication Section Examples from C-CDA 
+## Medication Section Examples from C-CDA 
 
 For all Medication examples the example task force agreed (8/28/2014) to only include institutionSpecified on the effectiveTime when the value is true. InstitutionSpecified indicates whether the exact timing is up to the party executing the schedule (e.g., to distinguish "every 8 hours" (false) from "3 times a day" (true)).

--- a/Medications/Single administration of medication/Readme.md
+++ b/Medications/Single administration of medication/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/13/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 
@@ -16,32 +16,32 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of two baby aspirin being administered at a single point in time. At the January 2014 San Antonio meeting of HL7, this approach was decided as appropriate for medication timing of a point in time. Subsequent to that meeting, the TTT validator was adjusted to accept this format for medication times.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * medications, Pre-coordinated medication code, single administration, point in time
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/051c409be64e64d6b35844891314a826e1496106](http://cdasearch.hl7.org/examples/view/051c409be64e64d6b35844891314a826e1496106)
 
-###Links
+### Links
 
 * [Single administration of medication at single point in time(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Single%20administration%20of%20medication/Single%20administration%20of%20medication%20at%20single%20point%20in%20time%28C-CDA2.1%29.xml)

--- a/Medications/Withdrawn Anitbiotics with varied dosing/Readme.md
+++ b/Medications/Withdrawn Anitbiotics with varied dosing/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Withdrawn
 * Example Task Force: 3/6/2014
 * SDWG: Withdarawn with preference for text - see comments 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 
@@ -14,16 +14,16 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * some [background](http://wiki.hl7.org/images/e/ee/2014-05-22_Critique_of_HL7_CDA_structured_tapering_dose_Azithromycin_example_w_Figures.docx) on the dissent for encoding this medication
 * This is an example of a medication with dosing that varies over time.
@@ -31,20 +31,20 @@
 * SDWG reviewed this example with the Pharmacy working group in February 2014. This dosing regimen may be characterized as a loading dose, but a similar approach could be used for a tapered dose as well. At the May 2014 Working Group the committee discussed whether this example would be better with just a free text sig which now exists as a new template in C-CDA R2.1
 
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
-###Keywords
+### Keywords
 
 * medications, Pre-coordinated medication code, dose frequency, tapered dose, loading dose
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/93c5eb52d4127fca75f4f29066b0e5e7eba9ca01](http://cdasearch.hl7.org/examples/view/93c5eb52d4127fca75f4f29066b0e5e7eba9ca01)
 
-###Links
+### Links
 
 * [Antibiotics with varied dosing(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Anitbiotics%20with%20varied%20dosing/Antibiotics%20with%20varied%20dosing%28C-CDA2.1%29.xml)

--- a/Medications/Withdrawn Patient reported oral medication/Readme.md
+++ b/Medications/Withdrawn Patient reported oral medication/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Withdrawn (temporarily)
 * Example Task Force:
 * SDWG:
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.1:2014-06-09
 
@@ -14,33 +14,33 @@
 
 * 2.16.840.1.113883.10.20.22.4.23:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Medications in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * Patients often report medications that they are taking, either self-prescribed or by another provider, and know the drug name but do not know any specific brand or dose. This is an example of how to record an herbal supplement (echinicea) that a patient has reported taking using the informant to denote that this is patient reported.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * medications
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4af85825f5f0d79db55c0d5b37bd66a4a0c51777](http://cdasearch.hl7.org/examples/view/4af85825f5f0d79db55c0d5b37bd66a4a0c51777)
 
-###Links
+### Links
 
 * [Patient reported oral medication no brand(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Medications/Patient%20reported%20oral%20medication/Patient%20reported%20oral%20medication%20no%20brand%28C-CDA2.1%29.xml)

--- a/Mental Status/Memory Impairment/Readme.md
+++ b/Mental Status/Memory Impairment/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/15/2017
 * SDWG: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Mental Status Section 2.16.840.1.113883.10.20.22.2.56:2015-08-01
 * Mental Status Result Observation 2.16.840.1.113883.10.20.22.4.74 and 2.16.840.1.113883.10.20.22.4.74:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Mental Status in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of mental (cognitive) impairment. It only illustrates one potential templated within the mental status section and was originally prepared for the ONC 2014 170.314(b)(2) Transitions of care - M) Functional and Cognitive Status.  Note that there are significant changes to functional and cognitive status in C-CDA 2.1 (including section breakout and deprecation of certain templates). This example represents the proper way to send a mental impairment in C-CDA R2.1.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) and John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * impairment
 
@@ -34,11 +34,11 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/d89e8ad8f365fa28c81fea3ff4287fca343a1293](http://cdasearch.hl7.org/examples/view/d89e8ad8f365fa28c81fea3ff4287fca343a1293)
 
 
-###Links
+### Links
 
 * [Memory Impairment(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Mental%20Status/Memory%20Impairment/Memory%20Impairment%28C-CDAR2.1%29.xml)

--- a/Mental Status/No Cognitive Impairment/Readme.md
+++ b/Mental Status/No Cognitive Impairment/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/18/2015, 6/15/2017
 * SDWG: 7/9/2015
 * SDWG C-CDA R2.1 Upgrade: 7/6/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Mental Status Section 2.16.840.1.113883.10.20.22.2.56:2015-08-01
 * Mental Status Result Observation 2.16.840.1.113883.10.20.22.4.74 and 2.16.840.1.113883.10.20.22.4.74:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Mental Status in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no cognitive impairment. It only illustrates one potential templated within the mental status section and was originally prepared for the ONC 2014 170.314(b)(2) Transitions of care - M) Functional and Cognitive Status. Note that there are significant changes to functional and cognitive status in C-CDA 2.1 (including section breakout and deprecation of certain templates). This example represents the proper way to send no cognitive impairment in C-CDA R2.1.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard) and John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * no impairment
 
@@ -35,11 +35,11 @@
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/4774a74b86f9cde7943fc987ffd1f6121f8ca578](http://cdasearch.hl7.org/examples/view/4774a74b86f9cde7943fc987ffd1f6121f8ca578)
 
 
-###Links
+### Links
 
 * [No Cognitive Impairment(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Mental%20Status/No%20Cognitive%20Impairment/No%20Cognitive%20Impairment%28C-CDAR2.1%29.xml)

--- a/Mental Status/Patient Health Questionnaire PHQ-9/Readme.md
+++ b/Mental Status/Patient Health Questionnaire PHQ-9/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/11/2019
 * SDWG: 7/25/2019
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Mental Status Section 2.16.840.1.113883.10.20.22.2.56:2015-08-01
 * Assessment Scale Observation 2.16.840.1.113883.10.20.22.4.69
 * Assessment Scale Supporting Observation 2.16.840.1.113883.10.20.22.4.86

--- a/Mental Status/Readme.md
+++ b/Mental Status/Readme.md
@@ -1,1 +1,1 @@
-##Mental Status Section Examples from C-CDA 
+## Mental Status Section Examples from C-CDA 

--- a/Notes/Discharge Note in Hospital Course/Readme.md
+++ b/Notes/Discharge Note in Hospital Course/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/14/2018
 * SDWG: 7/12/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 1.3.6.1.4.1.19376.1.5.3.1.3.5
 * 2.16.840.1.113883.10.20.22.2.65:2016-11-01
 * 2.16.840.1.113883.10.20.22.4.202
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Validated in an empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to record a single Discharge Note in a Hospital Course Section.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@waveoneassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * Note, Note Activity, Notes
 

--- a/Notes/Note directly attached to a Procedure/Readme.md
+++ b/Notes/Note directly attached to a Procedure/Readme.md
@@ -1,34 +1,34 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/14/2018
 * SDWG: 7/12/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.7.1
 * 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14
 * 2.16.840.1.113883.10.20.22.4.202:2016-11-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Validated in an empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to associate a Procedure Note with a Procedure in the Procedure section.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@waveoneassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * Note, Note Activity, Notes, Procedure
 

--- a/Notes/RTF Note/Readme.md
+++ b/Notes/RTF Note/Readme.md
@@ -15,7 +15,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 ### Comments

--- a/Notes/Readme.md
+++ b/Notes/Readme.md
@@ -1,1 +1,1 @@
-##Notes Section Examples from C-CDA 
+## Notes Section Examples from C-CDA 

--- a/Notes/Single Consultation Note/Readme.md
+++ b/Notes/Single Consultation Note/Readme.md
@@ -1,41 +1,41 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 11/16/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.65:2016-11-01
 * 2.16.840.1.113883.10.20.22.4.202
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Encounter in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to record a single Consultation Note.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * Note, Note Activity, Notes
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a13078d7c7ade0009585815](http://cdasearch.hl7.org/examples/view/5a13078d7c7ade0009585815)
 
-###Links
+### Links
 
 * [Single Consultation Note(C-CDA R2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Notes/Single%20Consultation%20Note/Single%20Consultation%20Note%28C-CDA%20R2.1%29.xml)

--- a/Plan of Treatment/Care Plan Goals and Instructions/Readme.md
+++ b/Plan of Treatment/Care Plan Goals and Instructions/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 8/20/15
 * SDWG: 9/10/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.10
 * 2.16.840.1.113883.10.20.22.2.10:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.44
@@ -14,34 +14,34 @@
 * 2.16.840.1.113883.10.20.22.4.12:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.121
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This example illustrates how to structure a Goals and Instructions for the 170.314(b)(2) Transitions of care - K) Care Plan (Goals and Instructions).
 
-###Certification
+### Certification
 
 * ONC
 
-###Custodian
+### Custodian
 
 * Lisa Nelson
 
-###Keywords
+### Keywords
 
 * Goal and instruction
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/dcff4e468368d5a82b7c3acef565de51b39e0544](http://cdasearch.hl7.org/examples/view/dcff4e468368d5a82b7c3acef565de51b39e0544)
 
-###Links
+### Links
 
 * [Care Plan Goals and Instructions(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Plan%20of%20Treatment/Care%20Plan%20Goals%20and%20Instructions/Care%20Plan%20Goals%20and%20Instructions%28C-CDAR2.1%29.xml)

--- a/Plan of Treatment/No Planned Tests/Readme.md
+++ b/Plan of Treatment/No Planned Tests/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/20/2014
 * SDWG: 4/16/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.10
 * 2.16.840.1.113883.10.20.22.2.10:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.44
@@ -13,30 +13,30 @@
 * 2.16.840.1.113883.10.20.22.4.41
 * 2.16.840.1.113883.10.20.22.4.41:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of how an author can record no planned tests.
 
-###Custodian
+### Custodian
 
 * John D'Amore and Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * no planned tests, no planned treatment
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/dc32be311928724a5e68411d70bd9d9326e3295e](http://cdasearch.hl7.org/examples/view/dc32be311928724a5e68411d70bd9d9326e3295e)
 
-###Links
+### Links
 
 * [No Planned Tests(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Plan%20of%20Treatment/No%20Planned%20Tests/No%20Planned%20Tests%28C-CDAR2.1%29.xml)

--- a/Plan of Treatment/Planned EKG/Readme.md
+++ b/Plan of Treatment/Planned EKG/Readme.md
@@ -1,40 +1,40 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/25/2015
 * SDWG: 2/11/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 2.16.840.1.113883.10.20.22.2.10
 * 2.16.840.1.113883.10.20.22.2.10:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.44
 * 2.16.840.1.113883.10.20.22.4.44:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This example illustrates how to structure a planned observation.
 
-###Custodian
+### Custodian
 
 * Brett Marquard, brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * basic plan of treatment observation, planned observation
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/99eff7589dbf2ee7591c8604fdaa68344635e7e4](http://cdasearch.hl7.org/examples/view/99eff7589dbf2ee7591c8604fdaa68344635e7e4)
 
-###Links
+### Links
 
 * [Planned EKG(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Plan%20of%20Treatment/Planned%20EKG/Planned%20EKG%28C-CDAR2.1%29.xml)

--- a/Plan of Treatment/Planned Encounter - Referral/Readme.md
+++ b/Plan of Treatment/Planned Encounter - Referral/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 9/24/2015
 * SDWG: 10/15/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * 1.3.6.1.4.1.19376.1.5.3.1.3.1
 * 2.16.840.1.113883.10.20.22.2.10
 * 2.16.840.1.113883.10.20.22.2.10:2014-06-09
@@ -15,34 +15,34 @@
 * 2.16.840.1.113883.10.20.22.4.19
 * 2.16.840.1.113883.10.20.22.4.19:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 *  This example illustrates how to structure a Referral for the 170.314(b)(2) Transitions of care - N) Referral
 
-###Certification
+### Certification
 
 * ONC
 
-###Custodian
+### Custodian
 
 * George Cole
 
-###Keywords
+### Keywords
 
 * Planned Encounter, Reason for Referral
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/f3cf8f6cc4fdc4f59d62dc765d2d13fa490f1b0c](http://cdasearch.hl7.org/examples/view/f3cf8f6cc4fdc4f59d62dc765d2d13fa490f1b0c)
 
-###Links
+### Links
 
 * [Planned Encounter - Reason for Referral(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Plan%20of%20Treatment/Planned%20Encounter%20-%20Referral/Planned%20Encounter%20-%20Reason%20for%20Referral%28C-CDAR2.1%29.xml)

--- a/Plan of Treatment/Readme.md
+++ b/Plan of Treatment/Readme.md
@@ -1,1 +1,1 @@
-##Plan of Treatment Section Examples from C-CDA 
+## Plan of Treatment Section Examples from C-CDA 

--- a/Problems/Active Problem/Readme.md
+++ b/Problems/Active Problem/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 10/2/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
@@ -15,29 +15,29 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure an active problem.
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * problems
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/b6f23e38249108eb5bc47905c949e9bb59fc33b4](http://cdasearch.hl7.org/examples/view/b6f23e38249108eb5bc47905c949e9bb59fc33b4)
 
-###Links
+### Links
 
 * [Active Problem(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Problems/Active%20Problem/Active%20Problem%28C-CDA2.1%29.xml)

--- a/Problems/Complete or Resolved Problem/Readme.md
+++ b/Problems/Complete or Resolved Problem/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/30/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
@@ -15,32 +15,32 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure a resolved problem, both by having a biological resolution date and a completed status of the concern.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * problems
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/614165f2d0c6ab2bf2bced565f41b5762ecfff44](http://cdasearch.hl7.org/examples/view/614165f2d0c6ab2bf2bced565f41b5762ecfff44)
 
-###Links
+### Links
 
 * [Resolved Problem(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Problems/Complete%20or%20Resolved%20Problem/Resolved%20Problem%28C-CDA2.1%29.xml)

--- a/Problems/No Known Problems/Readme.md
+++ b/Problems/No Known Problems/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/27/2015
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
@@ -15,30 +15,30 @@
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of no known problems.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
-###Keywords
+### Keywords
 
 * negation
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/7353a215efda8dfe3fbacb19abbb90756ce14bab](http://cdasearch.hl7.org/examples/view/7353a215efda8dfe3fbacb19abbb90756ce14bab)
 
-###Links
+### Links
 
 * [No Known Problems(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Problems/No%20Known%20Problems/No%20Known%20Problems%28C-CDA2.1%29.xml)

--- a/Problems/Patient Does Not Have Diabetes/Readme.md
+++ b/Problems/Patient Does Not Have Diabetes/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/5/2015
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.5.1:2015-08-01
@@ -14,33 +14,33 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * This is an example of an author asserting a patient does not have diabetes.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * negation
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/c1b6f960a26505ba83d7acb3ad7efc4d2ad10e4f](http://cdasearch.hl7.org/examples/view/c1b6f960a26505ba83d7acb3ad7efc4d2ad10e4f)
 
-###Links
+### Links
 
 * [Patient Does Not Have Diabetes(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Problems/Patient%20Does%20Not%20Have%20Diabetes/Patient%20Does%20Not%20Have%20Diabetes%28C-CDA2.1%29.xml)

--- a/Problems/Problem TargetSiteCode Qualifier/Readme.md
+++ b/Problems/Problem TargetSiteCode Qualifier/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 2/2/2017
 * SDWG: 5/18/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.6.1:2015-08-01
@@ -12,30 +12,30 @@
 * Problem Act: 2.16.840.1.113883.10.20.22.4.3:2015-08-01
 * Problem Observation: 2.16.840.1.113883.10.20.22.4.4:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
-###Comments
+### Comments
 
 * This is an example of adding a SNOMED qualifier to an ambiguous ICD-9 which could be used in qualifying patients related to QRDA/eCQM measure
 
-##Custodian
+## Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-##Keywords
+## Keywords
 
 * problem, qualifier, QRDA, eCQM, laterality, targetSiteCod
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/8a7c67dd2918d6a9e8ddd04e4522bf0c857f162b](http://cdasearch.hl7.org/examples/view/8a7c67dd2918d6a9e8ddd04e4522bf0c857f162b)
 
-###Links
+### Links
 
 * [Problem TargetSiteCode Qualifier(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Problems/Problem%20TargetSiteCode%20Qualifier/Problem%20TargetSiteCode%20Qualifier%28C-CDAR2.1%29.xml)

--- a/Problems/Readme.md
+++ b/Problems/Readme.md
@@ -1,1 +1,1 @@
-##Problem Section Examples from C-CDA 
+## Problem Section Examples from C-CDA 

--- a/Procedures/Procedure Refused/Readme.md
+++ b/Procedures/Procedure Refused/Readme.md
@@ -1,30 +1,30 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 12/8/2019
 * SDWG: 6/27/2019
 
-##Templates
+## Templates
 
 * Procedure Section: 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * Procedure Actitivy Procedure: 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * Reason: 2.16.840.1.113883.10.20.24.3.88:2014-12-01
 
-##Validation location:
+## Validation location:
 
 TBD
 
 Reference to full CDA sample: N/A
 
-##Comments
+## Comments
 
 * This is an example of a patient refusing a procedure.
 
-##Custodian
+## Custodian
 
 * Brett Marquard brett@waveoneassociates.comm (GitHub: brettmarquard)
 
-##Keywords
+## Keywords
 
 * procedure, negation
 

--- a/Procedures/Procedures Section Act Entry/Readme.md
+++ b/Procedures/Procedures Section Act Entry/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/22/2014
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.12:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates an act within a procedure section.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * problems
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/6fb118749dc61a404c472bc9680c7c595fd5da7c](http://cdasearch.hl7.org/examples/view/6fb118749dc61a404c472bc9680c7c595fd5da7c)
 
-###Links
+### Links
 
 * [Procedures Section Act(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Procedures/Procedures%20Section%20Act%20Entry/Procedures%20Section%20Act%28C-CDA2.1%29.xml)

--- a/Procedures/Procedures Section Observation Entry/Readme.md
+++ b/Procedures/Procedures Section Observation Entry/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/22/2014
@@ -6,38 +6,38 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.13:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Procedure in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how an observation within a procedure section.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * problems
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/7e7909bf02ee2ab3b327d7442eec96cc5f18141f](http://cdasearch.hl7.org/examples/view/7e7909bf02ee2ab3b327d7442eec96cc5f18141f)
 
-###Links
+### Links
 
 * [Procedures Section Observation(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Procedures/Procedures%20Section%20Observation%20Entry/Procedures%20Section%20Observation%28C-CDA2.1%29.xml)

--- a/Procedures/Procedures Section Procedure Entry - Colonoscopy/Readme.md
+++ b/Procedures/Procedures Section Procedure Entry - Colonoscopy/Readme.md
@@ -1,33 +1,33 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/19/2020
 * SDWG: 3/26/2020
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates a Colonoscopy procedure which with biopsy. Even if not biopsy, a colonscopy is recommended to be in a Procedure Activity Procedure.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@waveoneassociates.com (GitHub: brettmarquard)
 
-###Keywords
+### Keywords
 
 * procedure
 

--- a/Procedures/Procedures Section Procedure Entry/Readme.md
+++ b/Procedures/Procedures Section Procedure Entry/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/22/2014
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.7.1:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.14:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Problems in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example illustrates how a procedure which "alters the physical state" of the patient and should be classified as a procedure.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * problems
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/ff75bad48169a734962b34e6239fa12fa94cb554](http://cdasearch.hl7.org/examples/view/ff75bad48169a734962b34e6239fa12fa94cb554)
 
-###Links
+### Links
 
 * [Procedures Section Procedure(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Procedures/Procedures%20Section%20Procedure%20Entry/Procedures%20Section%20Procedure%28C-CDA2.1%29.xml)

--- a/Procedures/Readme.md
+++ b/Procedures/Readme.md
@@ -1,1 +1,1 @@
-##Procedure Section Examples from C-CDA 
+## Procedure Section Examples from C-CDA 

--- a/Quality/Quality Care Compliance in C-CDA/Readme.md
+++ b/Quality/Quality Care Compliance in C-CDA/Readme.md
@@ -1,29 +1,29 @@
-##Approval Status
+## Approval Status
 * Approval Status: Approved
 * Example Task Force: 1/3/2019
 * SDWG: 5/2/2019
 * CQI Involvement: 
 Reviewed in December 2017 with Examples TF, Reviewed 1/19/2018 with CQI. Reviewed April 2018 with CQI with approval to move forward with example. Reviewed during summer 2018 with Examples TF.   
 
-###QRDA Examples (for inclusion in C-CDA): 
+### QRDA Examples (for inclusion in C-CDA): 
 * QRDA Measure Section 2.16.840.1.113883.10.20.24.2.2
 * QRDA Measure Section QDM 2.16.840.1.113883.10.20.24.2.3
 * QRDA Measure Reference 2.16.840.1.113883.10.20.24.3.97
 * QRDA eMeasure Reference QDM 2.16.840.1.113883.10.20.24.3.98
 
-###Reference to full CDA sample
+### Reference to full CDA sample
 * https://github.com/jddamore/HL7-Task-Force-Examples/blob/master/C-CDAR2.1/QUALITY_in_ONC_CCD.xml
 
-###Validation location
+### Validation location
 * HL7 Schematron (Diameter Health hosted) January 2019
 
-###Comments: 
+### Comments: 
 * This is an example of how one could report quality measures in a C-CDA document. It is not a C-CDA template, but could be included as a section (since open template) and is conformant to QRDA1 Measure Section constraints. It would not be appropriate for US QRDA submission.
 
-###Custodian: 
+### Custodian: 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords: 
+### Keywords: 
 * QRDA1, eCQM, quality, care gap
 
 

--- a/Quality/Readme.md
+++ b/Quality/Readme.md
@@ -1,1 +1,1 @@
-##Quality Related Examples from C-CDA and QRDA 
+## Quality Related Examples from C-CDA and QRDA 

--- a/Referals - Planned and Completed/Readme.md
+++ b/Referals - Planned and Completed/Readme.md
@@ -1,1 +1,1 @@
-##Referral Examples from C-CDA 
+## Referral Examples from C-CDA 

--- a/Results/Readme.md
+++ b/Results/Readme.md
@@ -1,1 +1,1 @@
-##Result Section Examples from C-CDA 
+## Result Section Examples from C-CDA 

--- a/Results/Result panel with coded values of negative-positive/Readme.md
+++ b/Results/Result panel with coded values of negative-positive/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/21/2013 and 3/5/2015 and 2/13/2020
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
@@ -14,29 +14,29 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to encode positive and negative, which are common data types returned form lab equipment. While some technologies may represent this as a type of ST (string), it is logical and easily possible to encode this information using SNOMED-CT. This would allow structured examination of this information downstream as well as comparison to a structured reference range, as shown in the example.
 * Previously the examples task force approved this sample with the data type Coded Ordinal (CO) with the example name: Result panel with two ordinal values of negative-positive. The examples task force received feedback during implementation that CO is not commonly used, and CD is preferred. Updated the sample name to Result panel with coded values of negative-positive
 
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 * Brett Marquard brett@waveoneassociates.com (GitHub: brettmarquard)
 
 
 
-###Keywords
+### Keywords
 
 * Results
 

--- a/Results/Result with Multiple Reference Ranges/Readme.md
+++ b/Results/Result with Multiple Reference Ranges/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/22/2018
 * SDWG: 10/1/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.3:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
@@ -15,31 +15,31 @@
 * 2.16.840.1.113883.10.20.22.4.119
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a value from a lab result with multiple reference ranges: Negative (less than), Bordeline (equal), and Positive (greater than). 
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/7ef3b374ae0df4e24e1645a94ac1c9ebc79273bb](http://cdasearch.hl7.org/examples/view/7ef3b374ae0df4e24e1645a94ac1c9ebc79273bb)
 
-###Links
+### Links
 
 * [Result with an unstructured string as value urine color (C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Result%20with%20an%20unstructured%20string%20as%20value%20%28urine%20color%29/Result%20with%20an%20unstructured%20string%20as%20value%20urine%20color%20%28C-CDA2.1%29.xml)

--- a/Results/Result with an unstructured string as value (urine color)/Readme.md
+++ b/Results/Result with an unstructured string as value (urine color)/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/5/2015
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
@@ -14,32 +14,32 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a value from a lab result that may not be structured.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/7ef3b374ae0df4e24e1645a94ac1c9ebc79273bb](http://cdasearch.hl7.org/examples/view/7ef3b374ae0df4e24e1645a94ac1c9ebc79273bb)
 
-###Links
+### Links
 
 * [Result with an unstructured string as value urine color (C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Result%20with%20an%20unstructured%20string%20as%20value%20%28urine%20color%29/Result%20with%20an%20unstructured%20string%20as%20value%20urine%20color%20%28C-CDA2.1%29.xml)

--- a/Results/Result with greater than a specified value/Readme.md
+++ b/Results/Result with greater than a specified value/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/19/2015
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to encode "greater than" (but not equal to) a specific range when returned from lab equipment. The example is for a point-of-care glucometer, which measures blood sugar for diabetics. Often these devices may have an upper bound, 500 mg/dL is shown in this example. An inclusive tag of false is shown to demonstrate a non-inclusive range. The upper bound of the interval is positive infinity in this example. This example also includes two structured reference ranges for normal and high.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5acc416e7ad6fae1546c561cfc216eae8fb655de](http://cdasearch.hl7.org/examples/view/5acc416e7ad6fae1546c561cfc216eae8fb655de)
 
-###Links
+### Links
 
 * [Result with greater than a specified value(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Result%20with%20greater%20than%20a%20specified%20value/Result%20with%20greater%20than%20a%20specified%20value%28C-CDA2.1%29.xml)

--- a/Results/Result with lab location/Readme.md
+++ b/Results/Result with lab location/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 
 * Approval Status: Approved
@@ -9,7 +9,7 @@
 
 
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3:2015-08-01
@@ -22,42 +22,42 @@
 
 
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Results in empty CCD
 
 
 
 
-###Validation location
+### Validation location
 
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
 
-###Comments
+### Comments
 
 
 * This is an example of a results panel with Laboratory Location details as required by 2015 Certification Sender test 170.315(e1), in compliance with 42 CFR 493.1291(c)(1) through (7).
 
 
-###Custodian
+### Custodian
 
 
 * George Cole, george.cole@allscripts.com (GitHub: gecole)
 
 
-##Keywords
+## Keywords
 
 
 * Results, 2015 Certification, Lab Reporting Location
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/74b81ace7fa73c1baf08c7f372a88678012d4ae0](http://cdasearch.hl7.org/examples/view/74b81ace7fa73c1baf08c7f372a88678012d4ae0)
 
-###Links
+### Links
 
 * [Result with lab location(C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Result%20with%20lab%20location/Result%20with%20lab%20location%28C-CDAR2.1%29.xml)

--- a/Results/Result with non-numeric physical quantity and unit/Readme.md
+++ b/Results/Result with non-numeric physical quantity and unit/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 9/10/2015
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
@@ -12,29 +12,29 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a value from a lab with a discrete unit, but whose value is not a number, so the PQ datatype, the only type with a unit attribute, cannot be used.
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub:benjaminflessner)
-###Keywords
+### Keywords
 
 * results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5e01fab89d1b84fbf0ffeaa3c72501eb25d2ed03](http://cdasearch.hl7.org/examples/view/5e01fab89d1b84fbf0ffeaa3c72501eb25d2ed03)
 
-###Links
+### Links
 
 * [Result with non-numeric physical quantity and unit(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Result%20with%20non-numeric%20physical%20quantity%20and%20unit/Result%20with%20non-numeric%20physical%20quantity%20and%20unit%28C-CDA2.1%29.xml)

--- a/Results/Results Radiology with Image Narrative/Readme.md
+++ b/Results/Results Radiology with Image Narrative/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/10/2016
 * SDWG approved: 3/31/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1
@@ -15,33 +15,33 @@
 * 2.16.840.1.113883.10.20.22.4.2
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * This is an example of how to show a radiology result with narrative report in the results section. For the value, xsi-type equals ED (with reference) for encapsulated data.
 
-###Custodian
+### Custodian
 
 * John D'Amore, jdamore@diameterhealth.com (GitHub:jddamore)
 
-###Keywords
+### Keywords
 
 * Radiology, Imaging Study, Narrative
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/26323b29d7ae6e03727e442b0884aff337f8627a](http://cdasearch.hl7.org/examples/view/26323b29d7ae6e03727e442b0884aff337f8627a)
 
-###Links
+### Links
 
 * [Chest X ray with Narrative Report(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20Radiology%20with%20Image%20Narrative/Chest%20X%20ray%20with%20Narrative%20Report%28C-CDA2.1%29.xml)

--- a/Results/Results Unit Non-UCUM/Readme.md
+++ b/Results/Results Unit Non-UCUM/Readme.md
@@ -1,40 +1,40 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 2/27/2015
 * SDWG: 3/6/2015
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a value from a lab which didn't include a UCUM unit.
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub: benjaminflessner)
-###Keywords
+### Keywords
 
 * results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/898f46489ae99badc99e970a0412fc8dcb494ca0](http://cdasearch.hl7.org/examples/view/898f46489ae99badc99e970a0412fc8dcb494ca0)
 
-###Links
+### Links
 
 * [Results Unit Non-UCUM(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20Unit%20Non-UCUM/Results%20Unit%20Non-UCUM%28C-CDA2.1%29.xml)

--- a/Results/Results of Basic Metabolic Panel and Troponin/Readme.md
+++ b/Results/Results of Basic Metabolic Panel and Troponin/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 3/10/2016
 * SDWG approved: 3/31/2016
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1
@@ -15,36 +15,36 @@
 * 2.16.840.1.113883.10.20.22.4.2
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * Sample from Meaningful Use test data (inpatient data)
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 
 * John D'Amore, jdamore@diameterhealth.com (GitHub:jddamore)
 
-###Keywords
+### Keywords
 
 * Metabolic, Panel
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/ebbb7ccc5838f10077b2252813dc8cf1a42ba372](http://cdasearch.hl7.org/examples/view/ebbb7ccc5838f10077b2252813dc8cf1a42ba372)
 
-###Links
+### Links
 
 * [Basic Metabolic Panel with Troponin(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20of%20Basic%20Metabolic%20Panel%20and%20Troponin/Basic%20Metabolic%20Panel%20with%20Troponin%28C-CDA2.1%29.xml)

--- a/Results/Results of CO2 Test/Readme.md
+++ b/Results/Results of CO2 Test/Readme.md
@@ -1,11 +1,11 @@
-##Approval Status
+## Approval Status
 
 * Approval Status: Approved
 * Example Task Force: 5/7/2015
 * SDWG Approved: 6/4/2015
 * SDWG C-CDA R2.1 Upgrade: 2/2/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1
@@ -15,36 +15,36 @@
 * 2.16.840.1.113883.10.20.22.4.2
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * This example illustrates how to structure Laboratory Tests and Values/Results for the 170.314(b)(2) Transitions of care - I) Laboratory Tests and Values/Results.
 
-###Certification
+### Certification
 * ONC
 
-###Custodian
+### Custodian
 
 * Benjamin Flessner (GitHub:benjaminflessner)
 
-###Keywords
+### Keywords
 
 * Normal Result
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/72810ec4a92e1b63fc21c97b7e6e7c9aeb5a839a](http://cdasearch.hl7.org/examples/view/72810ec4a92e1b63fc21c97b7e6e7c9aeb5a839a)
 
-###Links
+### Links
 
 * [Results of CO2 Test Normal(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20of%20CO2%20Test/Results%20of%20CO2%20Test%20Normal%28C-CDA2.1%29.xml)

--- a/Results/Results panel with pending component/Readme.md
+++ b/Results/Results panel with pending component/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/1/2014
@@ -6,37 +6,37 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a results panel with pending component.
 
-###Custodian
+### Custodian
 
 *  Ed Donaldson, ed.donaldson@greenwayhealth.com (GitHub: donaldson-ed)
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/1a8f194b09ab0b7255ce2d138dc1a95227b6bb30](http://cdasearch.hl7.org/examples/view/1a8f194b09ab0b7255ce2d138dc1a95227b6bb30)
 
-###Links
+### Links
 
 * [Results panel with pending component(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20panel%20with%20pending%20component/Results%20panel%20with%20pending%20component%28C-CDA2.1%29.xml)

--- a/Results/Results with less than specific value/Readme.md
+++ b/Results/Results with less than specific value/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 12/15/2013
@@ -6,7 +6,7 @@
 * SDWG approved minor edits: 11/12/2015
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
@@ -14,34 +14,34 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of how to encode "less than or equal to" a specific range when returned from lab equipment. The example is for BNP, an immunoassay where the lower threshold for detection is often 5 pg/mL. The lower bound of the interval is zero in this example, even though this is none may be specified, since zero is the lower bound for measures of physical quantity. This example also includes a structured reference range.
 
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/6e922ff540fb0736928ffcc58b43741de70e785e](http://cdasearch.hl7.org/examples/view/6e922ff540fb0736928ffcc58b43741de70e785e)
 
-###Links
+### Links
 
 * [Results with less than specific value(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20with%20less%20than%20specific%20value/Results%20with%20less%20than%20specific%20value%28C-CDA2.1%29.xml)

--- a/Results/Results with translation unit/Readme.md
+++ b/Results/Results with translation unit/Readme.md
@@ -1,44 +1,44 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: Approved 2/27/2014
 * SDWG: 3/6/2014
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.3.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.1:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.2:2015-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Results in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a value from a lab which requires a translation for its unit. All units for physical quantities should be represent in UCUM.
 
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Results
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/c1f226a15c2024fc191b66ad51c0e3b52dc67885](http://cdasearch.hl7.org/examples/view/c1f226a15c2024fc191b66ad51c0e3b52dc67885)
 
-###Links
+### Links
 
 * [Results with translation unit(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Results/Results%20with%20translation%20unit/Results%20with%20translation%20unit%28C-CDA2.1%29.xml)

--- a/Social History/Birth Sex/Readme.md
+++ b/Social History/Birth Sex/Readme.md
@@ -1,41 +1,41 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/5/2016
 * SDWG: 2/9/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.4.200:2016-08-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 
-###Comments
+### Comments
 
 * This observation represents the sex of the patient at birth. It is the sex that is entered on the person's birth certificate at time of birth.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
 
 
 
-###Keywords
+### Keywords
 
 * Social History, Birth Sex
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/3b30a01004eccd6664935ff886a8c88830389324](http://cdasearch.hl7.org/examples/view/3b30a01004eccd6664935ff886a8c88830389324)
 
-###Links
+### Links
 
 * [Birth Sex(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Birth%20Sex/Birth%20Sex%28C-CDA2.1%29.xml)

--- a/Social History/Current Smoking Status/Readme.md
+++ b/Social History/Current Smoking Status/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/26/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Social History Section 2.16.840.1.113883.10.20.22.2.17:2015-08-01
@@ -14,32 +14,32 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * 2.16.840.1.113883.10.20.22.4.85:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of current smoking status. This example also includes a coordinating social history observation to convey the amount of smoking using a SNOMED code. This SNOMED code in the accompanying observation is not acceptable since smoking status, which is constrained by HL7 and Meaningful Use value set requirements. Each social history section shall only include a single smoking status.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Social History, Smoking
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/197a4b45cbb2162c21b557c4f6ad3cee7e9368ec](http://cdasearch.hl7.org/examples/view/197a4b45cbb2162c21b557c4f6ad3cee7e9368ec)
 
-###Links
+### Links
 
 * [Current Smoking Status(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Current%20Smoking%20Status/Current%20Smoking%20Status%28C-CDA2.1%29.xml)

--- a/Social History/Former Smoking Status/Readme.md
+++ b/Social History/Former Smoking Status/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/26/2014
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Social History Section 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * Smoking Status  2.16.840.1.113883.10.20.22.4.78:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a former smoker in smoking status. There is a variation in how effectiveTime/high is used since this represents when the patient stopped smoking, not when they stopped being a former smoker. C-CDA explicitly guides to this usage of effectiveTime. A best practice to avoid confusion is for each social history section to only include a single smoking status.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Social History, Smoking
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/498ea0b3bacdcc30827c4b7bb47b1a1304c52f46](http://cdasearch.hl7.org/examples/view/498ea0b3bacdcc30827c4b7bb47b1a1304c52f46)
 
-###Links
+### Links
 
 * [Former Smoking Status(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Former%20Smoking%20Status/Former%20Smoking%20Status%28C-CDA2.1%29.xml)

--- a/Social History/Never Smoking Status/Readme.md
+++ b/Social History/Never Smoking Status/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/26/2014
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * Social History Section 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * Smoking Status 2.16.840.1.113883.10.20.22.4.78:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of a never smoker in smoking status. A best practice to avoid confusion is for each social history section to only include a single smoking status.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Social History
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/78c4d5227e592dbb19f1950a84f22bb53f56ae41](http://cdasearch.hl7.org/examples/view/78c4d5227e592dbb19f1950a84f22bb53f56ae41)
 
-###Links
+### Links
 
 * [Never Smoking Status(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Never%20Smoking%20Status/Never%20Smoking%20Status%28C-CDA2.1%29.xml)

--- a/Social History/Not Pregnant/Readme.md
+++ b/Social History/Not Pregnant/Readme.md
@@ -1,44 +1,44 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/2/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.17
 * 2.16.840.1.113883.10.20.15.3.8
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of patient that is not pregnant.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
 
 
-###Keywords
+### Keywords
 
 * Social History, Pregnancy, negationInd
 
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b39fff02cc01f665c1fff](http://cdasearch.hl7.org/examples/view/5a0b39fff02cc01f665c1fff)
 
-###Links
+### Links
 
 * [Not Pregnant (C-CDAR2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Not%20Pregnant/Not%20Pregnant%20%28C-CDAR2.1%29.xml)

--- a/Social History/Readme.md
+++ b/Social History/Readme.md
@@ -1,1 +1,1 @@
-##Social History Section Examples from C-CDA 
+## Social History Section Examples from C-CDA 

--- a/Social History/Sexual Orientation Gender Identity/Readme.md
+++ b/Social History/Sexual Orientation Gender Identity/Readme.md
@@ -1,16 +1,16 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/11/2019
 * SDWG: 7/25/2019
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 * Social History Section 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * Social History Observation 2.16.840.1.113883.10.20.22.4.38:2018-08-01
 
 ### Reference to full CDA sample
 * https://github.com/jddamore/HL7-Task-Force-Examples/blob/master/C-CDAR2.1/MENTAL_STATUS_in_empty_C-CDA_2.1.xml 
-(This generates an issue on validator due to non-standard LOINC code@code, but this should be warning fixed in future schematron)
+( This generates an issue on validator due to non-standard LOINC code@code, but this should be warning fixed in future schematron)
 
 ### Validation location
 * HL7 Schematron (Diameter Health hosted) July 2019

--- a/Social History/Unknown Smoking Status/Readme.md
+++ b/Social History/Unknown Smoking Status/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 6/26/2014
@@ -6,38 +6,38 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.78:2014-06-09
 * 2.16.840.1.113883.10.20.22.4.119
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of unknown smoking status. There is a major variation in how no information is managed for smoking status. C-CDA explicitly guides to not utilize a nullFlavor for this information. Instead a SNOMED code should be used as demonstrated in the example. A best practice to avoid confusion is for each social history section to only include a single smoking status.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Social History, Smoking
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/c9c2657d9d9de7824b3afdc51cc442a8b899aea5](http://cdasearch.hl7.org/examples/view/c9c2657d9d9de7824b3afdc51cc442a8b899aea5)
 
-###Links
+### Links
 
 * [Unknown Smoking Status(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Unknown%20Smoking%20Status/Unknown%20Smoking%20Status%28C-CDA2.1%29.xml)

--- a/Social History/Unknown if Pregnant/Readme.md
+++ b/Social History/Unknown if Pregnant/Readme.md
@@ -1,43 +1,43 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 11/2/2017
 * SDWG: 11/30/2017
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.17:2015-08-01
 * 2.16.840.1.113883.10.20.22.2.17
 * 2.16.840.1.113883.10.20.15.3.8
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 
 * Social history in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is an example of unknown pregnancy status.
 
-###Custodian
+### Custodian
 
 * Brett Marquard brett@riverrockassociates.com (GitHub: brettmarquard)
 
 
-###Keywords
+### Keywords
 
 * Social History, Pregnancy, Unknown
 
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/5a0b39fff02cc01f665c2000](http://cdasearch.hl7.org/examples/view/5a0b39fff02cc01f665c2000)
 
-###Links
+### Links
 
 * [Unknown if Pregnant.xml](https://github.com/HL7/C-CDA-Examples/tree/master/Social%20History/Unknown%20if%20Pregnant/Unknown%20if%20Pregnant.xml)

--- a/Unstructured/CDA reference PDF/Readme.md
+++ b/Unstructured/CDA reference PDF/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Unstructured Document (V3) 2.16.840.1.113883.10.20.22.1.10:2015-08-01 (open)
 * US General Header 2.16.840.1.113883.10.20.22.1.1:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Unstructured Document specification using a referenced pdf.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Unstructured Document, Reference Document
 

--- a/Unstructured/CDA with Embedded PDF 1/Readme.md
+++ b/Unstructured/CDA with Embedded PDF 1/Readme.md
@@ -1,32 +1,32 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Pending
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Unstructured Document (V3) 2.16.840.1.113883.10.20.22.1.10:2015-08-01 (open)
 * US General Header 2.16.840.1.113883.10.20.22.1.1:2014-06-09 (open)
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This sample originates from the 2014-11-12 publication.
 * This example shows a CDA document that conforms to the C-CDA Unstructured Document specification using an embedded 64-bit encoded pdf.
 
-###Custodian
+### Custodian
 
 * Sean McIlvenna (sean.mcilvenna@lantanagroup.com)
 
 
-###Keywords
+### Keywords
 
 * C-CDA Unstructured Document, Embedded Document
 

--- a/Unstructured/CDA with Embedded PDF 2/Readme.md
+++ b/Unstructured/CDA with Embedded PDF 2/Readme.md
@@ -1,10 +1,10 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 7/26/2018
 * SDWG: 10/1/2018
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * Unstructured Document (V3) 2.16.840.1.113883.10.20.22.1.10:2015-08-01 (open)
 
@@ -12,25 +12,25 @@
 * PACP Header 2.16.840.1.113883.4.823.1.2.1:2016-07-01
 * PACP Document 2.16.840.1.113883.4.823.1.1.1:2016-07-01
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * This is a full CDA example
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This example shows a CDA document that conforms to the C-CDA Unstructured Document specification using an embedded 64-bit encoded pdf. It also conforms to the HL7 Personal Advance Care Plan specification and the C-CDA Patient Generated Document header.
 
-###Custodian
+### Custodian
 
 * Lisa Nelson lnelson@max.md
 
 
-###Keywords
+### Keywords
 
 * C-CDA Unstructured Document, PACP, Embedded Document
 

--- a/Unstructured/CDA with Embedded Text plain/README.md
+++ b/Unstructured/CDA with Embedded Text plain/README.md
@@ -13,7 +13,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 ### Comments
 

--- a/Unstructured/Readme.md
+++ b/Unstructured/Readme.md
@@ -1,1 +1,1 @@
-##Unstructured Document Examples 
+## Unstructured Document Examples 

--- a/Vital Signs/Growth Charts Examples/README.md
+++ b/Vital Signs/Growth Charts Examples/README.md
@@ -15,7 +15,7 @@
 * Problems in empty CCD
 
 ### Reference to Online Validator Used
-* https://sitenv.org/sandbox-ccda/ccda-validator
+* https://site.healthit.gov/sandbox-ccda/ccda-validator
 
 ### Comments
 * This example illustrates three vital sign observations with LOINC codes and reference growth chart names for BMI percentile, weight-for-length percentile, and head circumference percentile. or example, this illustrates how to send that a child's BMI percentile is 45 %, and that the CDC (Boys 2-20 years) growth chart was used to determine the value.

--- a/Vital Signs/Heart Rate Rhythm/Readme.md
+++ b/Vital Signs/Heart Rate Rhythm/Readme.md
@@ -19,7 +19,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 ### Comments

--- a/Vital Signs/Panel of Vital Signs (Oxygen Concentration Included)/Readme.md
+++ b/Vital Signs/Panel of Vital Signs (Oxygen Concentration Included)/Readme.md
@@ -20,7 +20,7 @@
 
 ### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
 ### Comments

--- a/Vital Signs/Panel of Vital Signs in Metric Units/Readme.md
+++ b/Vital Signs/Panel of Vital Signs in Metric Units/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/30/2014
@@ -6,7 +6,7 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 
 * 2.16.840.1.113883.10.20.22.2.4.1:2015-08-01
@@ -14,32 +14,32 @@
 * 2.16.840.1.113883.10.20.22.4.119
 * Vital Sign Observation 2.16.840.1.113883.10.20.22.4.27:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Vital Signs in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is panel of the nine common vital signs collected on an adult in metric units. Note that body surface area (BSA), head circumference and height (lying) are not included.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Vital Signs
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/713669406c546a843ed2b78cfd99080f87834191](http://cdasearch.hl7.org/examples/view/713669406c546a843ed2b78cfd99080f87834191)
 
-###Links
+### Links
 
 * [Panel of Vital Signs in Metric Units(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Vital%20Signs/Panel%20of%20Vital%20Signs%20in%20Metric%20Units/Panel%20of%20Vital%20Signs%20in%20Metric%20Units%28C-CDA2.1%29.xml)

--- a/Vital Signs/Panel of Vital Signs in Mixed Metric-Imperial Units/Readme.md
+++ b/Vital Signs/Panel of Vital Signs in Mixed Metric-Imperial Units/Readme.md
@@ -1,4 +1,4 @@
-##Approval Status 
+## Approval Status 
 
 * Approval Status: Approved
 * Example Task Force: 5/30/2014
@@ -6,39 +6,39 @@
 
 * SDWG C-CDA R2.1 Upgrade: 12/1/2016    
 
-###C-CDA 2.1 Example:
+### C-CDA 2.1 Example:
 
 * 2.16.840.1.113883.10.20.22.2.4.1:2015-08-01
 * Vital Sign Organizer 2.16.840.1.113883.10.20.22.4.26:2015-08-01
 * 2.16.840.1.113883.10.20.22.4.119
 * Vital Sign Observation 2.16.840.1.113883.10.20.22.4.27:2014-06-09
 
-###Reference to full CDA sample:
+### Reference to full CDA sample:
 * Vital Signs in empty CCD
 
 
-###Validation location
+### Validation location
 
-* [SITE](https://sitenv.org/sandbox-ccda/ccda-validator)
+* [SITE](https://site.healthit.gov/sandbox-ccda/ccda-validator)
 
 
-###Comments
+### Comments
 
 * This is panel of the nine common vital signs collected on an adult in mixed metric/imperial units. Note that body surface area (BSA), head circumference and height (lying) are not included.
-###Custodian
+### Custodian
 
 * John D'Amore jdamore@diameterhealth.com (GitHub: jddamore)
 
 
 
-###Keywords
+### Keywords
 
 * Vital Signs
 
-###Permalink
+### Permalink
 
 * [http://cdasearch.hl7.org/examples/view/637843e87f54bfd065ab0a93526b41bf3031c003](http://cdasearch.hl7.org/examples/view/637843e87f54bfd065ab0a93526b41bf3031c003)
 
-###Links
+### Links
 
 * [Panel of Vital Signs in Mixed Metric-Imperial Units(C-CDA2.1).xml](https://github.com/HL7/C-CDA-Examples/tree/master/Vital%20Signs/Panel%20of%20Vital%20Signs%20in%20Mixed%20Metric-Imperial%20Units/Panel%20of%20Vital%20Signs%20in%20Mixed%20Metric-Imperial%20Units%28C-CDA2.1%29.xml)

--- a/Vital Signs/Readme.md
+++ b/Vital Signs/Readme.md
@@ -1,1 +1,1 @@
-##Vital Sign Section Examples from C-CDA 
+## Vital Sign Section Examples from C-CDA 


### PR DESCRIPTION
This one just makes two tiny housekeeping updates across all the readmes:

1. Switches them to GitHub-flavored markdown (ie adds a space after hashtags in headers so that they actually render properly on GitHub)
2. Updates link to SITE C-CDA validator (the site recently moved, so all the links were out of date)