### PR TITLE
Adding examples from C-CDA IG and Companion Guide

### DIFF
--- a/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/Admission Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/Admission Diagnosis Section (V3) Example.xml
@@ -1,0 +1,17 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.43" extension="2015-08-01"/>
+  <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" displayName="Hospital Admission Diagnosis">
+    <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1" displayName="Admission Diagnosis"></translation>
+  </code>
+  <title>HOSPITAL ADMISSION DIAGNOSIS</title>
+  <text>Appendicitis</text>
+  <entry>
+    <act classCode="ACT" moodCode="EVN">
+      <!--Admission Diagnosis template -->
+            ...
+        
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/README.md
+++ b/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Admission Diagnosis Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.43

--- a/Guide Examples/Admission Medication (V2)_2.16.840.1.113883.10.20.22.4.36/Admission Medication (V2) Example.xml
+++ b/Guide Examples/Admission Medication (V2)_2.16.840.1.113883.10.20.22.4.36/Admission Medication (V2) Example.xml
@@ -1,0 +1,12 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.36" extension="2014-06-09" />
+  <code code="42346-7" />
+  <entryRelationship typeCode="SUBJ">
+    <substanceAdministration classCode="SBADM" moodCode="EVN">
+      <!-- ** MEDICATION ACTIVITY V2 ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+        ...
+    
+    </substanceAdministration>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Admission Medication (V2)_2.16.840.1.113883.10.20.22.4.36/README.md
+++ b/Guide Examples/Admission Medication (V2)_2.16.840.1.113883.10.20.22.4.36/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Admission Medication (V2)
+ 
+2.16.840.1.113883.10.20.22.4.36

--- a/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/Advance Directive Observation (V3) Example.xml
+++ b/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/Advance Directive Observation (V3) Example.xml
@@ -1,0 +1,98 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- ** Advance Directive Observation** -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.48" 
+        extension="2015-08-01" />
+    <id root="9b54c3c9-1673-49c7-aef9-b037ed72ed27" />
+    <code code="304251008" displayName="Resuscitation" 
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+      <translation code="75320-2" 
+                                    displayName="Advance Directive"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+    </code>
+    <statusCode code="completed" />
+    <effectiveTime>
+      <low value="20110213" />
+      <high nullFlavor="NA" />
+    </effectiveTime>
+    <value xsi:type="CD" 
+          code="304253006" 
+          codeSystem="2.16.840.1.113883.6.96" 
+          codeSystemName="SNOMED-CT" 
+          displayName="Not for resuscitation">
+      <originalText>Do not resuscitate</originalText>
+    </value>
+    <author>
+      <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+      <time value="201308011235-0800" />
+      <assignedAuthor>
+        <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+        <code code="163W00000X" 
+            displayName="Registered nurse" 
+            codeSystem="2.16.840.1.113883.6.101" 
+            codeSystemName="Health Care Provider Taxonomy (HIPAA)" />
+        <assignedPerson>
+          <name>
+            <given>Nurse</given>
+            <family>Nightingale</family>
+            <suffix>RN</suffix>
+          </name>
+        </assignedPerson>
+        <representedOrganization classCode="ORG">
+          <id root="2.16.840.1.113883.19.5" />
+          <name>Good Health Hospital</name>
+        </representedOrganization>
+      </assignedAuthor>
+    </author>
+    <participant typeCode="VRF">
+      <templateId root="2.16.840.1.113883.10.20.1.58" />
+      <time value="201302013" />
+      <participantRole>
+        <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+        <code code="163W00000X" 
+             codeSystem="2.16.840.1.113883.6.101" 
+             codeSystemName="Health Care Provider Taxonomy (HIPAA)" 
+             displayName="Registered nurse" />
+        <addr>
+          ...
+        </addr>
+        <telecom value="tel:(995)555-1006" use="WP" />
+        <playingEntity>
+          <code code="63161005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Principal" />
+          <name>
+            <given>Nurse</given>
+            <family>Florence</family>
+            <suffix>RN</suffix>
+          </name>
+        </playingEntity>
+      </participantRole>
+    </participant>
+    <participant typeCode="CST">
+      <participantRole classCode="AGNT">
+        <code code="MTH" codeSystem="2.16.840.1.113883.5.111" displayName="Mother" />
+        <addr>
+          ...
+        </addr>
+        <telecom value="tel:(999)555-1212" use="WP" />
+        <playingEntity>
+          <code code="63161005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Principal" />
+          <name>
+            <prefix>Mrs.</prefix>
+            <given>Martha</given>
+            <family>Jones</family>
+          </name>
+        </playingEntity>
+      </participantRole>
+    </participant>
+    <reference typeCode="REFR">
+      <externalDocument>
+        <id root="b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3" />
+        <text mediaType="application/pdf">
+          <reference value="AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf" />
+        </text>
+        <versionNumber value="1" />
+      </externalDocument>
+    </reference>
+  </observation>
+</entry>

--- a/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/README.md
+++ b/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Advance Directive Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.48

--- a/Guide Examples/Advance Directive Organizer (V2)_2.16.840.1.113883.10.20.22.4.108/Advance Directive Organizer (V2) Example.xml
+++ b/Guide Examples/Advance Directive Organizer (V2)_2.16.840.1.113883.10.20.22.4.108/Advance Directive Organizer (V2) Example.xml
@@ -1,0 +1,51 @@
+<organizer classCode="CLUSTER" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.108" extension="2015-08-01" />
+  <id root="631F0E95-F055-4FA2-AF10-3AE036CAD2EC" extension="10.1.1" />
+  <code code="45473-6" 
+    displayName="advance directive - living will" 
+    codeSystem="2.16.840.1.113883.6.1" 
+    codeSystemName="LOINC">
+    <originalText>
+      <reference value="#ADO1" />
+    </originalText>
+  </code>
+  <statusCode code="completed" />
+  <!-- Author Participation -->
+  <author>
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    <time value="20130807150000-0500" />
+    <assignedAuthor>
+      <id extension="5555555551" root="2.16.840.1.113883.4.6" />
+      <code code="163W00000X" 
+        displayName="Registered nurse" 
+        codeSystem="2.16.840.1.113883.6.101"
+        codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+      <assignedPerson>
+        <name>
+          <given>Nurse</given>
+          <family>Nightingale</family>
+          <suffix>RN</suffix>
+        </name>
+      </assignedPerson>
+      <representedOrganization classCode="ORG">
+        <id root="2.16.840.1.113883.19.5" />
+        <name>Good Health Hospital</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <component>
+    <!-- Advance Directive Observation (V3)  -->
+    ...
+  
+  </component>
+  <component>
+    <!-- Advance Directive Observation (V3) -->
+    ...
+  
+  </component>
+  <component>
+    <!-- Advance Directive Observation (V3) -->
+    ...
+  
+  </component>
+</organizer>

--- a/Guide Examples/Advance Directive Organizer (V2)_2.16.840.1.113883.10.20.22.4.108/README.md
+++ b/Guide Examples/Advance Directive Organizer (V2)_2.16.840.1.113883.10.20.22.4.108/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Advance Directive Organizer (V2)
+ 
+2.16.840.1.113883.10.20.22.4.108

--- a/Guide Examples/Advance Directives Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.21.1/Advance Directives Section (V3) Example.xml
+++ b/Guide Examples/Advance Directives Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.21.1/Advance Directives Section (V3) Example.xml
@@ -1,0 +1,23 @@
+<section>
+  <!-- C-CDA Advance Directives Section (required entries)template id -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.21.1" extension="2015-08-01" />
+  <code code="42348-3" codeSystem="2.16.840.1.113883.6.1" />
+  <title>ADVANCE DIRECTIVES</title>
+  <text>
+       Narrative Text
+    </text>
+  <entry typeCode="DRIV">
+    <organizer classCode="CLUSTER" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.108" />
+      <!-- ***Advance Directive Organizer template -->
+      <id root="af6ebdf2-d996-11e2-a5b8-f23c91aec05e" />
+    </organizer>
+  </entry>
+  <entry typeCode="DRIV">
+    <organizer classCode="CLUSTER" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.108" />
+      <!-- ***Advance Directive Organizer template -->
+      <id root="af6ebdf2-d996-11e2-a5b8-f23c91aec05e" />
+    </organizer>
+  </entry>
+</section>

--- a/Guide Examples/Advance Directives Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.21.1/README.md
+++ b/Guide Examples/Advance Directives Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.21.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Advance Directives Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.21.1

--- a/Guide Examples/Age Observation_2.16.840.1.113883.10.20.22.4.31/Age Observation Example.xml
+++ b/Guide Examples/Age Observation_2.16.840.1.113883.10.20.22.4.31/Age Observation Example.xml
@@ -1,0 +1,9 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.31" />
+  <!-- Age observation -->
+  <code code="445518008" 
+        codeSystem="2.16.840.1.113883.6.96"
+        displayName="Age At Onset" />
+  <statusCode code="completed" />
+  <value xsi:type="PQ" value="57" unit="a" />
+</observation>

--- a/Guide Examples/Age Observation_2.16.840.1.113883.10.20.22.4.31/README.md
+++ b/Guide Examples/Age Observation_2.16.840.1.113883.10.20.22.4.31/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Age Observation
+ 
+2.16.840.1.113883.10.20.22.4.31

--- a/Guide Examples/Allergies and Intolerances Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.6.1/Allergies and Intolerances Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Allergies and Intolerances Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.6.1/Allergies and Intolerances Section (entries required) (V3) Example.xml
@@ -1,0 +1,18 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01" />
+  <code code="48765-2" displayName="Allergies, adverse reactions, alerts" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <title>Allergies</title>
+  <text>
+      ...
+    </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.30" extension="2014-06-09" />
+      <!--   Allergy Concern Act template   -->
+        ...
+      
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Allergies and Intolerances Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.6.1/README.md
+++ b/Guide Examples/Allergies and Intolerances Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.6.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Allergies and Intolerances Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.6.1

--- a/Guide Examples/Allergy - Intolerance Observation (V2)_2.16.840.1.113883.10.20.22.4.7/Allergy - Intolerance Observation (V2) Example.xml
+++ b/Guide Examples/Allergy - Intolerance Observation (V2)_2.16.840.1.113883.10.20.22.4.7/Allergy - Intolerance Observation (V2) Example.xml
@@ -1,0 +1,56 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- ** Allergy observation ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.7" extension="2014-06-09" />
+  <id root="901db0f8-9355-4794-81cd-fd951ef07917" />
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+  <!-- Observation statusCode represents the status of the act of observing -->
+  <statusCode code="completed" />
+  <effectiveTime>
+    <!-- The low value reflects the date of onset of the allergy -->
+    <low nullFlavor="UNK" />
+    <!-- The high value reflects when the allergy was known to be resolved 
+            (and will generally be absent) -->
+  </effectiveTime>
+  <value xsi:type="CD" code="419199007" displayName="Allergy to substance" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <author>
+    <time value="201010110915-0800" />
+    <assignedAuthor>
+      <id extension="222223333" root="1.1.1.1.1.1.1.3" />
+    </assignedAuthor>
+  </author>
+  <participant typeCode="CSM">
+    <participantRole classCode="MANU">
+      <playingEntity classCode="MMAT">
+        <code code="2670" displayName="Codeine" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+      </playingEntity>
+    </participantRole>
+  </participant>
+  <entryRelationship typeCode="MFST" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Reaction observation ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.9" extension="2014-06-09" />
+      <id root="38c63dea-1a43-4f84-ab71-1ffd04f6a1dd" />
+      <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+      <text>
+        <reference value="#reaction2" />
+      </text>
+      <statusCode code="completed" />
+      <effectiveTime>
+        <low nullFlavor="UNK" />
+      </effectiveTime>
+      <value xsi:type="CD" code="56018004" displayName="Wheezing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Severity observation ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.8" extension="2014-06-09" />
+      <code code="SEV" displayName="Severity Observation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+      <text>
+        <reference value="#allergyseverity2" />
+      </text>
+      <statusCode code="completed" />
+      <value xsi:type="CD" code="255604002" displayName="Mild" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Allergy - Intolerance Observation (V2)_2.16.840.1.113883.10.20.22.4.7/README.md
+++ b/Guide Examples/Allergy - Intolerance Observation (V2)_2.16.840.1.113883.10.20.22.4.7/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Allergy - Intolerance Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.7

--- a/Guide Examples/Allergy Concern Act (V3)_2.16.840.1.113883.10.20.22.4.30/Allergy Concern Act (V3) Example.xml
+++ b/Guide Examples/Allergy Concern Act (V3)_2.16.840.1.113883.10.20.22.4.30/Allergy Concern Act (V3) Example.xml
@@ -1,0 +1,67 @@
+<act classCode="ACT" moodCode="EVN">
+  <!-- ** Allergy Concern Act ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.30" extension="2015-08-01" />
+  <id root="36e3e930-7b14-11db-9fe1-0800200c9a66" />
+  <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
+  <!-- The statusCode represents the need to continue tracking the allergy -->
+  <!-- This is of ongoing concern to the provider -->
+  <statusCode code="active" />
+  <effectiveTime>
+    <!-- The low value represents when the allergy was first recorded in the 
+             patient's chart -->
+    <!-- Concern started being tracked as an active issue on May 1, 1998 -->
+    <low value="199805011145-0800" />
+  </effectiveTime>
+  <author typeCode="AUT">
+    <!-- Same as Concern effectiveTime/low -->
+    <time value="199805011145-0800" />
+    <assignedAuthor>
+      <id extension="555555555" root="1.1.1.1.1.1.1.2" />
+    </assignedAuthor>
+  </author>
+  <entryRelationship typeCode="SUBJ">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Allergy observation ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.7" extension="2014-06-09" />
+      <id root="4adc1020-7b14-11db-9fe1-0800200c9a66" />
+      <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+      <!-- Observation statusCode represents the status of the act of observing -->
+      <statusCode code="completed" />
+      <effectiveTime>
+        <!-- The low value reflects the date of onset of the allergy -->
+        <!-- Based on patient symptoms, presumed onset is May 1, 1998 -->
+        <low value="19980501" />
+        <!-- The high value reflects when the allergy was known to be resolved 
+                    (and will generally be absent) -->
+      </effectiveTime>
+      <value xsi:type="CD" code="419199007" displayName="Allergy to substance" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+      <author typeCode="AUT">
+        <time value="199805011145-0800" />
+        <assignedAuthor>
+          <id extension="222223333" root="1.1.1.1.1.1.1.3" />
+        </assignedAuthor>
+      </author>
+      <participant typeCode="CSM">
+        <participantRole classCode="MANU">
+          <playingEntity classCode="MMAT">
+            <code code="70618" displayName="Penicillin" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+          </playingEntity>
+        </participantRole>
+      </participant>
+      <entryRelationship typeCode="MFST" inversionInd="true">
+        <observation classCode="OBS" moodCode="EVN">
+          <!-- ** Reaction observation ** -->
+          <templateId root="2.16.840.1.113883.10.20.22.4.9" extension="2014-06-09" />
+          <id root="4adc1020-7b14-11db-9fe1-0800200c9a64" />
+          <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+          <statusCode code="completed" />
+          <effectiveTime>
+            <low value="200802260800-0800" />
+            <high value="2008022801200-0800" />
+          </effectiveTime>
+          <value xsi:type="CD" code="422587007" codeSystem="2.16.840.1.113883.6.96" displayName="Nausea" />
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Allergy Concern Act (V3)_2.16.840.1.113883.10.20.22.4.30/README.md
+++ b/Guide Examples/Allergy Concern Act (V3)_2.16.840.1.113883.10.20.22.4.30/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Allergy Concern Act (V3)
+ 
+2.16.840.1.113883.10.20.22.4.30

--- a/Guide Examples/Anesthesia Section (V2)_2.16.840.1.113883.10.20.22.2.25/Anesthesia Section (V2) Example.xml
+++ b/Guide Examples/Anesthesia Section (V2)_2.16.840.1.113883.10.20.22.2.25/Anesthesia Section (V2) Example.xml
@@ -1,0 +1,26 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.25" extension="2014-06-09" />
+  <code code="59774-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=" Anesthesia" />
+  <title>Procedure Anesthesia</title>
+  <text> Conscious sedation with propofol 200 mg IV </text>
+  <entry>
+    <procedure classCode="PROC" moodCode="EVN">
+      <!-- Procedure activity procedure template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09" />
+        ...
+      
+        
+        
+    </procedure>
+  </entry>
+  <entry>
+    <substanceAdministration classCode="SBADM" moodCode="EVN">
+      <!-- Medication activity template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+        ...
+      
+        
+        
+    </substanceAdministration>
+  </entry>
+</section>

--- a/Guide Examples/Anesthesia Section (V2)_2.16.840.1.113883.10.20.22.2.25/README.md
+++ b/Guide Examples/Anesthesia Section (V2)_2.16.840.1.113883.10.20.22.2.25/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Anesthesia Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.25

--- a/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/Assessment Scale Observation Example.xml
+++ b/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/Assessment Scale Observation Example.xml
@@ -1,0 +1,23 @@
+   
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.69"/>
+  <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0b"/>
+  <code code="54614-3" 
+             displayName="Brief Interview for Mental Status"
+             codeSystem="2.16.840.1.113883.6.1" 
+             codeSystemName="LOINC"/>
+  <derivationExpr>Text description of the calculation</derivationExpr>
+  <statusCode code="completed"/>
+  <effectiveTime value="20120214"/>
+  <!-- Summed score of the component values -->
+  <value xsi:type="INT" value="7"/>
+  <entryRelationship typeCode="COMP">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.86"/>
+            
+            . . .
+
+    
+        
+    </entryRelationship>
+  </observation>

--- a/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/README.md
+++ b/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Assessment Scale Observation
+ 
+2.16.840.1.113883.10.20.22.4.69

--- a/Guide Examples/Assessment Scale Supporting Observation_2.16.840.1.113883.10.20.22.4.86/Assessment Scale Supporting Observation Example.xml
+++ b/Guide Examples/Assessment Scale Supporting Observation_2.16.840.1.113883.10.20.22.4.86/Assessment Scale Supporting Observation Example.xml
@@ -1,0 +1,9 @@
+ 
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.86"/>
+  <id root="f4dce790-8328-11db-9fe1-0800200c9a44"/>
+  <code code="248240001" displayName="motor response"
+          codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED"/>
+  <statusCode code="completed"/>
+  <value xsi:type="INT" value="3"/>
+</observation> 

--- a/Guide Examples/Assessment Scale Supporting Observation_2.16.840.1.113883.10.20.22.4.86/README.md
+++ b/Guide Examples/Assessment Scale Supporting Observation_2.16.840.1.113883.10.20.22.4.86/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Assessment Scale Supporting Observation
+ 
+2.16.840.1.113883.10.20.22.4.86

--- a/Guide Examples/Assessment Section_2.16.840.1.113883.10.20.22.2.8/Assessment Section Example.xml
+++ b/Guide Examples/Assessment Section_2.16.840.1.113883.10.20.22.2.8/Assessment Section Example.xml
@@ -1,0 +1,10 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+  <code codeSystem="2.16.840.1.113883.6.1" 
+         codeSystemName="LOINC" code="51848-0" 
+         displayName="ASSESSMENTS"/>
+  <title>ASSESSMENTS</title>
+  <text>
+      ...
+   </text>
+</section>

--- a/Guide Examples/Assessment Section_2.16.840.1.113883.10.20.22.2.8/README.md
+++ b/Guide Examples/Assessment Section_2.16.840.1.113883.10.20.22.2.8/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Assessment Section
+ 
+2.16.840.1.113883.10.20.22.2.8

--- a/Guide Examples/Assessment and Plan Section (V2)_2.16.840.1.113883.10.20.22.2.9/Assessment and Plan Section (V2) Example.xml
+++ b/Guide Examples/Assessment and Plan Section (V2)_2.16.840.1.113883.10.20.22.2.9/Assessment and Plan Section (V2) Example.xml
@@ -1,0 +1,17 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.9" extension="2014-06-09" />
+  <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="51847-2" displayName="ASSESSMENT AND PLAN" />
+  <title>ASSESSMENT AND PLAN</title>
+  <text>
+      ...
+   </text>
+  <entry>
+    <act moodCode="RQO" classCode="ACT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.39" />
+      <!--   Planned Act  -->
+         ...
+      
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Assessment and Plan Section (V2)_2.16.840.1.113883.10.20.22.2.9/README.md
+++ b/Guide Examples/Assessment and Plan Section (V2)_2.16.840.1.113883.10.20.22.2.9/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Assessment and Plan Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.9

--- a/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/Existing Author Reference Example.xml
+++ b/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/Existing Author Reference Example.xml
@@ -1,0 +1,10 @@
+<author>
+  <time value="201308011235-0800" />
+  <assignedAuthor>
+    <!-- 
+            This id points to a participant already described 
+            elsewhere in the document 
+        -->
+    <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+  </assignedAuthor>
+</author>

--- a/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/New Author Participant Example.xml
+++ b/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/New Author Participant Example.xml
@@ -1,0 +1,19 @@
+<author>
+  <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+  <time value="201308011235-0800" />
+  <assignedAuthor>
+    <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+    <code code="163W00000X" codeSystem="2.16.840.1.113883.5.53" codeSystemName="Health Care Provider Taxonomy" displayName="Registered nurse" />
+    <assignedPerson>
+      <name>
+        <given>Nurse</given>
+        <family>Nightingale</family>
+        <suffix>RN</suffix>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+      <id root="2.16.840.1.113883.19.5" />
+      <name>Good Health Hospital</name>
+    </representedOrganization>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/README.md
+++ b/Guide Examples/Author Participation_2.16.840.1.113883.10.20.22.4.119/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Author Participation
+ 
+2.16.840.1.113883.10.20.22.4.119

--- a/Guide Examples/Authorization Activity_2.16.840.1.113883.10.20.1.19/Authorization Activity Example.xml
+++ b/Guide Examples/Authorization Activity_2.16.840.1.113883.10.20.1.19/Authorization Activity Example.xml
@@ -1,0 +1,13 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.1.19"/>
+  <id root="f4dce790-8328-11db-9fe1-0800200c9a66"/>
+  <code nullFlavor="NA" />
+  <entryRelationship typeCode="SUBJ">
+    <procedure classCode="PROC" moodCode="PRMS">
+      <code code="73761001" 
+                     codeSystem="2.16.840.1.113883.6.96"
+	             codeSystemName="SNOMED CT" 
+                     displayName="Colonoscopy"/>
+    </procedure>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Authorization Activity_2.16.840.1.113883.10.20.1.19/README.md
+++ b/Guide Examples/Authorization Activity_2.16.840.1.113883.10.20.1.19/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Authorization Activity
+ 
+2.16.840.1.113883.10.20.1.19

--- a/Guide Examples/Birth Sex Observation_2.16.840.1.113883.10.20.22.4.200/Birth Sex Example.xml
+++ b/Guide Examples/Birth Sex Observation_2.16.840.1.113883.10.20.22.4.200/Birth Sex Example.xml
@@ -1,0 +1,22 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- New templateId for Birth Sex -->
+  <!-- Not asserting conformance to Social History Observation due to different vocab. -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.200" extension="2016-06-01"/>
+  <code code="76689-9" codeSystem="2.16.840.1.113883.6.1" 
+            displayName="Sex Assigned At Birth"/>
+  <text>
+    <reference value="#BSex_Narrative1"/>
+  </text>
+  <statusCode code="completed"/>
+  <!-- effectiveTime if present should match birthTime -->
+  <!-- Request  name change to QRDA value set (2.16.840.1.113762.1.4.1) - ONC Birth Sex -->
+  <value xsi:type="CD" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" 
+            code="F" displayName="Female">
+    <originalText>
+      <reference value="#BSex_value"/>
+    </originalText>
+  </value>
+  <author>
+           ...
+    </author>
+</observation>

--- a/Guide Examples/Birth Sex Observation_2.16.840.1.113883.10.20.22.4.200/README.md
+++ b/Guide Examples/Birth Sex Observation_2.16.840.1.113883.10.20.22.4.200/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Birth Sex Observation
+ 
+2.16.840.1.113883.10.20.22.4.200

--- a/Guide Examples/Boundary Observation_2.16.840.1.113883.10.20.6.2.11/Boundary Observation Example.xml
+++ b/Guide Examples/Boundary Observation_2.16.840.1.113883.10.20.6.2.11/Boundary Observation Example.xml
@@ -1,0 +1,6 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.11"/>
+  <code code="113036" codeSystem="1.2.840.10008.2.16.4"
+        displayName="Frames for Display"/>
+  <value xsi:type="INT" value="1"/>
+</observation>

--- a/Guide Examples/Boundary Observation_2.16.840.1.113883.10.20.6.2.11/README.md
+++ b/Guide Examples/Boundary Observation_2.16.840.1.113883.10.20.6.2.11/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Boundary Observation
+ 
+2.16.840.1.113883.10.20.6.2.11

--- a/Guide Examples/Brand Name Example_2.16.840.1.113883.10.20.22.4.301/Brand Name Example.xml
+++ b/Guide Examples/Brand Name Example_2.16.840.1.113883.10.20.22.4.301/Brand Name Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.301" extension="2019-06-21"/>
+	<code code="C71898" displayName="Brand Name"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#BrandName_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Brand Name Example_2.16.840.1.113883.10.20.22.4.301/README.md
+++ b/Guide Examples/Brand Name Example_2.16.840.1.113883.10.20.22.4.301/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Brand Name Example
+ 
+2.16.840.1.113883.10.20.22.4.301

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Caregiver participant Example.xml
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Caregiver participant Example.xml
@@ -1,0 +1,22 @@
+<participant typeCode="IND">
+  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  <!-- Caregiver -->
+  <associatedEntity classCode="CAREGIVER">
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <addr>
+      <streetAddressLine>17 Daws Rd.</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(999)555-1212" use="WP" />
+    <associatedPerson>
+      <name>
+        <prefix>Mrs.</prefix>
+        <given>Martha</given>
+        <family>Jones</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Patient authenticator Example.xml
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Patient authenticator Example.xml
@@ -1,0 +1,14 @@
+<!-- This authenticator represents patient agreement or 
+  sign-off of the Care Plan-->
+<authenticator>
+  <time value="20130802" />
+  <signatureCode code="S" />
+  <sdtc:signatureText mediaType="text/xml" representation="B64">omSJUEdmde9j44zmMiromSJUEdmde9j44zmMirdMDSsWdIJdksIJR3373jeu83
+    6edjzMMIjdMDSsWdIJdksIJR3373jeu83MNYD83jmMdomSJUEdmde9j44zmMir ...
+    MNYD83jmMdomSJUEdmde9j44zmMir6edjzMMIjdMDSsWdIJdksIJR3373jeu83
+    4zmMir6edjzMMIjdMDSsWdIJdksIJR3373jeu83==</sdtc:signatureText>
+  <assignedEntity>
+    <id extension="996-756-495" root="2.16.840.1.113883.19.5" />
+    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+  </assignedEntity>
+</authenticator>

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Review Example.xml
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan Review Example.xml
@@ -1,0 +1,13 @@
+<!-- This participant represents the Care Plan review. 
+  If the date in the time element is in the past, 
+  then this review has already taken place. 
+  If the date in the time element is in the future, 
+  then this is the date of the next scheduled review. -->
+<!-- This example shows a Care Plan Review that has already taken place -->
+<participant typeCode="IND">
+  <functionCode code="425268008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Review of Care Plan" />
+  <time value="20130801" />
+  <associatedEntity classCode="ASSIGNED">
+    <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan performer Example.xml
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan performer Example.xml
@@ -1,0 +1,23 @@
+<performer typeCode="PRF">
+  <time value="20130715223615-0800" />
+  <assignedEntity>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="59058001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="General Physician" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan relatedDocument Example.xml
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/Care Plan relatedDocument Example.xml
@@ -1,0 +1,10 @@
+<!-- This document is the second in a set - relatedDocument
+  describes the parent document-->
+<relatedDocument typeCode="RPLC">
+  <parentDocument>
+    <id root="223769be-f6ee-4b04-a0ce-b56ae998c880" />
+    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Plan" />
+    <setId root="004bb033-b948-4f4c-b5bf-a8dbd7d8dd40" />
+    <versionNumber value="1" />
+  </parentDocument>
+</relatedDocument>

--- a/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/README.md
+++ b/Guide Examples/Care Plan (V2)_2.16.840.1.113883.10.20.22.1.15/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Care Plan (V2)
+ 
+2.16.840.1.113883.10.20.22.1.15

--- a/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act.xml
+++ b/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act.xml
@@ -1,0 +1,48 @@
+<!--Care Team Organizer-->
+<entry>
+  <organizer classCode="CLUSTER" moodCode="EVN">
+    <templateId root="2.16.840.1.113883.10.20.22.4.500" extension="2019-07-01"/>
+...
+              
+    <!--NEW Care Team Organizer Entry Template ID and extension-->
+...              
+              
+    <!-- #1 Care Team Member Act - This component is a care team member who is a provider -->
+    <component>
+      <act classCode="PCPR" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.500.1" extension="2019-07-01"/>
+        <id root="1.5.5.5.5.5.5"/>
+        <code code="85847-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team Information"/>
+        <!--Care Team Member Status - https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion-->
+        <statusCode code="active"/>
+        <effectiveTime xsi:type="IVL_TS">
+          <low value="201810081426-0500"/>
+        </effectiveTime>
+        <!--Attributes about the provider member - name-->
+        <performer typeCode="PRF">
+          <functionCode 
+            xmlns="urn:hl7-org:sdtc" code="PCP" displayName="primary care physician"
+                          codeSystem="2.16.840.1.113883.5.88" codeSystemName="ParticipationFunction">
+            <originalText 
+              xmlns="urn:hl7-org:v3">
+              <reference value="#CT1_M01"></reference>
+            </originalText>
+          </functionCode>
+          <!-- A care team member role -->
+          <assignedEntity>
+            <id root="B00B14E8-CDE4-48EA-8A09-01BC4945122A" extension="1"/>
+            <id root="1.5.5.5.5.5.5"/>
+            <assignedPerson>
+              <name>
+                <given>John</given>
+                <given>D</given>
+                <family>Smith</family>,
+                <suffix>MD</suffix>
+              </name>
+            </assignedPerson>
+          </assignedEntity>
+        </performer>
+      </act>
+    </component>
+  </organizer>
+</entry>

--- a/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/README.md
+++ b/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Care Team Member Act
+ 
+2.16.840.1.113883.10.20.22.4.500.1

--- a/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/Care Team Organizer Example 1.xml
+++ b/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/Care Team Organizer Example 1.xml
@@ -1,0 +1,59 @@
+<!--Care Team Organizer-->
+<entry>
+  <organizer classCode="CLUSTER" moodCode="EVN">
+    <templateId root="2.16.840.1.113883.10.20.22.4.500" extension="2019-07-01"/>
+    <!--NEW Care Team Organizer Entry Template ID and extension-->
+    <id root="1.1.1.1.1.1"/>
+    <code code="86744-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team">
+      <originalText>
+        <reference value="#CareTeamName1"></reference>
+      </originalText>
+    </code>
+    <!--Care Team Status - https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion-->
+    <statusCode code="active"/>
+    <effectiveTime>
+      <low value="201810081426-0500"/>
+    </effectiveTime>
+    <!-- This participant is the Care Team Lead (1..1)-->
+    <!-- Care Team Lead is one of the contained care team members in the list of care team members-->
+    <!--<participant typeCode="PPRF">
+    <!-\-<This id matches at least one of the member's id in the Care Team Member act template>-\-><participantRole><id root="1.5.5.5.5.5.5"/></participantRole></participant>-->
+    <!-- #1 Care Team Member Act - This component is a care team member who is a provider -->
+    <component>
+      <act classCode="PCPR" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.500.1" extension="2019-07-01"/>
+        <id root="1.5.5.5.5.5.5"/>
+        <code code="85847-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team Information"/>
+        <!--Care Team Member Status - https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion-->
+        <statusCode code="active"/>
+        <effectiveTime xsi:type="IVL_TS">
+          <low value="201810081426-0500"/>
+        </effectiveTime>
+        <!--Attributes about the provider member - name-->
+        <performer typeCode="PRF">
+          <functionCode 
+            xmlns="urn:hl7-org:sdtc" code="PCP" displayName="primary care physician"
+                          codeSystem="2.16.840.1.113883.5.88" codeSystemName="ParticipationFunction">
+            <originalText 
+              xmlns="urn:hl7-org:v3">
+              <reference value="#CT1_M01"></reference>
+            </originalText>
+          </functionCode>
+          <!-- A care team member role -->
+          <assignedEntity>
+            <id root="B00B14E8-CDE4-48EA-8A09-01BC4945122A" extension="1"/>
+            <id root="1.5.5.5.5.5.5"/>
+            <assignedPerson>
+              <name>
+                <given>John</given>
+                <given>D</given>
+                <family>Smith</family>,
+                <suffix>MD</suffix>
+              </name>
+            </assignedPerson>
+          </assignedEntity>
+        </performer>
+      </act>
+    </component>
+  </organizer>
+</entry>

--- a/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/README.md
+++ b/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Care Team Organizer
+ 
+2.16.840.1.113883.10.20.22.4.500

--- a/Guide Examples/Care Team Type Observation_2.16.840.1.113883.10.20.22.4.500.2/Care Team Type Example.xml
+++ b/Guide Examples/Care Team Type Observation_2.16.840.1.113883.10.20.22.4.500.2/Care Team Type Example.xml
@@ -1,0 +1,12 @@
+
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.500.2" extention="2019-07-01"/>
+  <!--Care Team Type-->
+  <code code="86744-0" 
+        codeSystem="2.16.840.1.113883.6.1"
+        displayName="Care team" />
+  <statusCode code="completed" />
+  <value xsi:type="CD" code="LA28865-6" 
+        codeSystem="2.16.840.1.113883.6.1"
+        displayName="Longitudinal care-coordination focused care team"/>
+</observation>

--- a/Guide Examples/Care Team Type Observation_2.16.840.1.113883.10.20.22.4.500.2/README.md
+++ b/Guide Examples/Care Team Type Observation_2.16.840.1.113883.10.20.22.4.500.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Care Team Type Observation
+ 
+2.16.840.1.113883.10.20.22.4.500.2

--- a/Guide Examples/Care Teams Section_2.16.840.1.113883.10.20.22.2.500/Care Teams Section.xml
+++ b/Guide Examples/Care Teams Section_2.16.840.1.113883.10.20.22.2.500/Care Teams Section.xml
@@ -1,0 +1,37 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+  <code code="85847-2" codeSystem="2.16.840.1.113883.6.1"/>
+  <title>Patient Care Teams</title>
+  <text>
+    <list>
+      <item>
+        <content ID= "CareTeamName1">Inpatient Diabetes Care Team</content> (
+        <content>Active</content>) (10/08/2018 - )
+                      
+        <table>
+          <thead>
+            <tr>
+              <th>Member</th>
+              <th>Role on Team</th>
+              <th>Status</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Dr. Henry Seven </td>
+              <td ID="CT1_M01">PCP</td>
+              <td>(Active)</td>
+              <td>10/18/2019</td>
+            </tr>
+          </tbody>
+        </table>
+      </item>
+    </list>
+  </text>
+  <entry>
+    <!--Care Team Organizer-->
+... entry info here, if coded data available for care team members... 
+          
+  </entry>
+</section>

--- a/Guide Examples/Care Teams Section_2.16.840.1.113883.10.20.22.2.500/README.md
+++ b/Guide Examples/Care Teams Section_2.16.840.1.113883.10.20.22.2.500/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Care Teams Section
+ 
+2.16.840.1.113883.10.20.22.2.500

--- a/Guide Examples/Caregiver Characteristics_2.16.840.1.113883.10.20.22.4.72/Caregiver Characteristics Example.xml
+++ b/Guide Examples/Caregiver Characteristics_2.16.840.1.113883.10.20.22.4.72/Caregiver Characteristics Example.xml
@@ -1,0 +1,16 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.72"/>
+  <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0c"/>
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="422615001"
+                 codeSystem="2.16.840.1.113883.6.96"
+                 displayName="caregiver difficulty providing 
+                              physical care"/>
+  <participant typeCode="IND">
+    <participantRole classCode="CAREGIVER">
+      <code code="MTH" codeSystem="2.16.840.1.113883.5.111"
+                    displayName="Mother"/>
+    </participantRole>
+  </participant>
+</observation>

--- a/Guide Examples/Caregiver Characteristics_2.16.840.1.113883.10.20.22.4.72/README.md
+++ b/Guide Examples/Caregiver Characteristics_2.16.840.1.113883.10.20.22.4.72/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Caregiver Characteristics
+ 
+2.16.840.1.113883.10.20.22.4.72

--- a/Guide Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/Catalog Number Example.xml
+++ b/Guide Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/Catalog Number Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.302" extension="2019-06-21"/>
+	<code code="C99286" displayName="Catalog Number"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#CatalogNumber_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/README.md
+++ b/Guide Examples/Catalog_Number_Observation_2.16.840.1.113883.10.20.22.4.302/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Catalog
+ 
+Number

--- a/Guide Examples/Characteristics of Home Environment_2.16.840.1.113883.10.20.22.4.109/Characteristics of Home Environment Example.xml
+++ b/Guide Examples/Characteristics of Home Environment_2.16.840.1.113883.10.20.22.4.109/Characteristics of Home Environment Example.xml
@@ -1,0 +1,10 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- ** Characteristics of Home Environment** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.109" />
+  <id root="37f76c51-6411-4e1d-8a37-957fd49d2ceg" />
+  <code code="75274-1" codeSystem="2.16.840.1.113883.6.1"
+          displayName="Characteristics of residence" />
+  <statusCode code="completed" />
+  <effectiveTime value="20130312" />
+  <value xsi:type="CD" code="308899009" displayName="unsatisfactory living conditions (finding)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+</observation>

--- a/Guide Examples/Characteristics of Home Environment_2.16.840.1.113883.10.20.22.4.109/README.md
+++ b/Guide Examples/Characteristics of Home Environment_2.16.840.1.113883.10.20.22.4.109/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Characteristics of Home Environment
+ 
+2.16.840.1.113883.10.20.22.4.109

--- a/Guide Examples/Chief Complaint Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/Chief Complaint Section Example.xml
+++ b/Guide Examples/Chief Complaint Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/Chief Complaint Section Example.xml
@@ -1,0 +1,10 @@
+<section>
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1"/>
+  <code code="10154-3" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="CHIEF COMPLAINT"/>
+  <title> CHIEF COMPLAINT</title>
+  <text>Back Pain</text>
+</section>
+

--- a/Guide Examples/Chief Complaint Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/README.md
+++ b/Guide Examples/Chief Complaint Section_1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Chief Complaint Section
+ 
+1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1

--- a/Guide Examples/Chief Complaint and Reason for Visit Section_2.16.840.1.113883.10.20.22.2.13/Chief Complaint and Reason for Visit Section Example.xml
+++ b/Guide Examples/Chief Complaint and Reason for Visit Section_2.16.840.1.113883.10.20.22.2.13/Chief Complaint and Reason for Visit Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+  <code code="46239-0" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="CHIEF COMPLAINT AND REASON FOR VISIT"/>
+  <title> CHIEF COMPLAINT</title>
+  <text>Back Pain</text>
+</section>

--- a/Guide Examples/Chief Complaint and Reason for Visit Section_2.16.840.1.113883.10.20.22.2.13/README.md
+++ b/Guide Examples/Chief Complaint and Reason for Visit Section_2.16.840.1.113883.10.20.22.2.13/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Chief Complaint and Reason for Visit Section
+ 
+2.16.840.1.113883.10.20.22.2.13

--- a/Guide Examples/Code Observations_2.16.840.1.113883.10.20.6.2.13/Code Observations Example.xml
+++ b/Guide Examples/Code Observations_2.16.840.1.113883.10.20.6.2.13/Code Observations Example.xml
@@ -1,0 +1,13 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.13"/>
+  <code code="18782-3" codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Study observation"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="309530007" 
+        codeSystem="2.16.840.1.113883.6.96" 
+        codeSystemName="SNOMED CT" 
+        displayName="Hilar mass"/>
+  <!-- entryRelationship elements referring to SOP Instance Observations 
+       or Quantity Measurement Observations may appear here -->
+</observation>

--- a/Guide Examples/Code Observations_2.16.840.1.113883.10.20.6.2.13/README.md
+++ b/Guide Examples/Code Observations_2.16.840.1.113883.10.20.6.2.13/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Code Observations
+ 
+2.16.840.1.113883.10.20.6.2.13

--- a/Guide Examples/Comment Activity_2.16.840.1.113883.10.20.22.4.64/Comment Activity Example.xml
+++ b/Guide Examples/Comment Activity_2.16.840.1.113883.10.20.22.4.64/Comment Activity Example.xml
@@ -1,0 +1,33 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+  <code code="48767-8" displayName="Annotation Comment" 
+        codeSystemName="LOINC" 
+        codeSystem="2.16.840.1.113883.6.1"/>
+  <text>The patient stated that he was looking forward to an upcoming 
+    vacation to New York with his family.  He was concerned that he may
+    not have enough medication for the trip.  An additional prescription 
+    was provided to cover that period of time.
+        
+    <reference value="#PntrtoSectionText"/>
+  </text>
+  <author>
+    <time value="20050329224411+0500"/>
+    <assignedAuthor>
+      <id extension="KP00017" root="2.16.840.1.113883.19.5"/>
+      <addr>
+        <streetAddressLine>21 North Ave.</streetAddressLine>
+        <city>Burlington</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(555)555-1003"/>
+      <assignedPerson>
+        <name>
+          <given>Henry</given>
+          <family>Seven</family>
+        </name>
+      </assignedPerson>
+    </assignedAuthor>
+  </author>
+</act>

--- a/Guide Examples/Comment Activity_2.16.840.1.113883.10.20.22.4.64/README.md
+++ b/Guide Examples/Comment Activity_2.16.840.1.113883.10.20.22.4.64/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Comment Activity
+ 
+2.16.840.1.113883.10.20.22.4.64

--- a/Guide Examples/Company Name Observation_2.16.840.1.113883.10.20.22.4.303/Company Name Example.xml
+++ b/Guide Examples/Company Name Observation_2.16.840.1.113883.10.20.22.4.303/Company Name Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.303" extension="2019-06-21"/>
+	<code code="C54131" displayName="Company Name"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#CompanyName_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Company Name Observation_2.16.840.1.113883.10.20.22.4.303/README.md
+++ b/Guide Examples/Company Name Observation_2.16.840.1.113883.10.20.22.4.303/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Company Name Observation
+ 
+2.16.840.1.113883.10.20.22.4.303

--- a/Guide Examples/Complications Section (V3)_2.16.840.1.113883.10.20.22.2.37/Complications Section (V3) Example.xml
+++ b/Guide Examples/Complications Section (V3)_2.16.840.1.113883.10.20.22.2.37/Complications Section (V3) Example.xml
@@ -1,0 +1,15 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.37" extension="2015-08-01" />
+  <code code="55109-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Complications" />
+  <title>Complications</title>
+  <text>Asthmatic symptoms while under general anesthesia.</text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Problem Observation -->
+         ...
+      
+        
+        
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Complications Section (V3)_2.16.840.1.113883.10.20.22.2.37/README.md
+++ b/Guide Examples/Complications Section (V3)_2.16.840.1.113883.10.20.22.2.37/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Complications Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.37

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note (V2) inFulfillmentOf Example.xml
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note (V2) inFulfillmentOf Example.xml
@@ -1,0 +1,6 @@
+<inFulfillmentOf typeCode="FLFS">
+  <order classCode="ACT" moodCode="RQO">
+    <id root="2.16.840.1.113883.6.96" extension="1298989898" />
+    <code code="388975008" displayName="Weight Reduction Consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="CPT4" />
+  </order>
+</inFulfillmentOf>

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note Callback participant Example.xml
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note Callback participant Example.xml
@@ -1,0 +1,22 @@
+<participant typeCode="CALLBCK">
+  <time value="20050329224411+0500" />
+  <associatedEntity classCode="ASSIGNED">
+    <id extension="99999999" root="2.16.840.1.113883.4.6" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <addr>
+      <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:555-555-1002" />
+    <associatedPerson>
+      <name>
+        <given>Henry</given>
+        <family>Seven</family>
+        <suffix>DO</suffix>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note structuredBody Example.xml
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note structuredBody Example.xml
@@ -1,0 +1,164 @@
+<component>
+  <structuredBody>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.6.1" 
+                    extension="2015-08-01" />
+        <!-- Allergies section template -->
+        <code code="48765-2" codeSystem="2.16.840.1.113883.6.1" 
+                      displayName="Allergies, adverse reactions, alerts" codeSystemName="LOINC" />
+        <title>Allergies, Adverse Reactions, Alerts</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.8" />
+        <!-- Assessment-->
+        <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" 
+                      code="51848-0" displayName="ASSESSMENT" />
+        <title>ASSESSMENT</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+        <!-- History of Present Illness -->
+        <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" 
+                      code="10164-2" displayName="HISTORY OF PRESENT ILLNESS" />
+        <title>HISTORY OF PRESENT ILLNESS</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <!--MEDICATION SECTION (V2) (coded entries required) -->
+        <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09" />
+        <code code="10160-0" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="HISTORY OF MEDICATION USE" />
+        <title>MEDICATIONS</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.2.10" extension="2015-08-01" />
+        <!-- Physical Exam (V3) -->
+        <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" 
+                      code="29545-1" displayName="PHYSICAL FINDINGS" />
+        <title>PHYSICAL EXAMINATION</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.10" 
+                    extension="2014-06-09"" />
+        <!--  Plan of Treatment Section (V2) template  -->
+        <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="Treatment plan" />
+        <title>PLAN OF CARE</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <!-- Problem Section (entries required) (V3) -->
+        <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+        <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="PROBLEM LIST" />
+        <title>PROBLEMS</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.7" 
+                    extension="2014-06-09" />
+        <!-- Procedures Section (entries optional) (V2) -->
+        <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="HISTORY OF PROCEDURES" />
+        <title>PROCEDURES</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" 
+                    extension="2014-06-09" />
+        <!-- Reason for Referral Section V2  -->
+        <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" 
+                      code="42349-1" displayName="REASON FOR REFERRAL" />
+        <title>REASON FOR REFERRAL</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01" />
+        <!-- Results Section (entries required) (V3) -->
+        <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="RESULTS" />
+        <title>RESULTS</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01" />
+        <!-- Social history section (V3)-->
+        <code code="29762-2" codeSystem="2.16.840.1.113883.6.1"
+                      displayName="Social History" />
+        <title>SOCIAL HISTORY</title>
+                ...
+            
+            
+            
+      </section>
+    </component>
+    <component>
+      <section>
+        <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+        <!-- Vital Signs Section (V3)-->
+        <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" 
+                      codeSystemName="LOINC" displayName="VITAL SIGNS" />
+        <title>VITAL SIGNS</title>
+                        ...
+            
+            
+            
+      </section>
+    </component>
+  </structuredBody>
+</component>

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/README.md
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Consultation Note (V3)
+ 
+2.16.840.1.113883.10.20.22.1.4

--- a/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) Performer Example.xml
+++ b/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) Performer Example.xml
@@ -1,0 +1,24 @@
+<performer typeCode="PRF">
+  <functionCode code="PP" displayName="Primary Performer" codeSystem="2.16.840.1.113883.12.443" codeSystemName="Provider Role">
+    <originalText>Primary Care Provider</originalText>
+  </functionCode>
+  <assignedEntity>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
+    <addr>
+            ...
+        </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+           ...
+        </representedOrganization>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) author Example.xml
+++ b/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) author Example.xml
@@ -1,0 +1,23 @@
+<author>
+  <time value="201209151030-0800" />
+  <assignedAuthor>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) serviceEvent Example.xml
+++ b/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/CCD (V2) serviceEvent Example.xml
@@ -1,0 +1,18 @@
+<documentationOf>
+  <serviceEvent classCode="PCPR">
+    <!-- The effectiveTime reflects the provision of care summarized in the document. 
+             In this scenario, the provision of care summarized is the lifetime for
+             the patient -->
+    <effectiveTime>
+      <low value="19750501" />
+      <!-- The low value represents when the summarized provision of care began. 
+                 In this scenario, the patient's date of birth -->
+      <high value="20120915" />
+      <!-- The high value represents when the summarized provision of care being 
+                 ended. In this scenario, when chart summary was created -->
+    </effectiveTime>
+    <performer typeCode="PRF">
+           ....
+        </performer>
+  </serviceEvent>
+</documentationOf>

--- a/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/README.md
+++ b/Guide Examples/Continuity of Care Document (CCD) (V3)_2.16.840.1.113883.10.20.22.1.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Continuity of Care Document (CCD) (V3)
+ 
+2.16.840.1.113883.10.20.22.1.2

--- a/Guide Examples/Course of Care Section_2.16.840.1.113883.10.20.22.2.64/Course of Care Section Example.xml
+++ b/Guide Examples/Course of Care Section_2.16.840.1.113883.10.20.22.2.64/Course of Care Section Example.xml
@@ -1,0 +1,23 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.64"
+             extension="2014-06-09" />
+  <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+          code="8648-8" displayName="Hospital Course Narrative" />
+  <title>Hospital Course of Care</title>
+  <text>
+    <paragraph>This patient was only recently transferred after a recurrent 
+        GI bleed as described below.</paragraph>
+    <paragraph>He presented to the ER today c/o a dark stool yesterday 
+        but a normal brown stool today. On exam he was hypotensive in the 
+        80s resolved after .... .... .... </paragraph>
+    <paragraph>Lab at discharge: Glucose 112, BUN 16, creatinine 1.1, 
+        electrolytes normal. H. pylori antibody pending. Admission 
+        hematocrit 16%, discharge hematocrit 29%. WBC 7300, platelet 
+        count 256,000. Urinalysis normal. Urine culture: No growth. INR 
+        1.1, PTT 40.</paragraph>
+    <paragraph>He was transfused with 6 units of packed red blood cells 
+        with .... .... ....</paragraph>
+    <paragraph>GI evaluation 12 September: Colonoscopy showed single red 
+       clot in .... .... ....</paragraph>
+  </text>
+</section>

--- a/Guide Examples/Course of Care Section_2.16.840.1.113883.10.20.22.2.64/README.md
+++ b/Guide Examples/Course of Care Section_2.16.840.1.113883.10.20.22.2.64/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Course of Care Section
+ 
+2.16.840.1.113883.10.20.22.2.64

--- a/Guide Examples/Coverage Activity (V3)_2.16.840.1.113883.10.20.22.4.60/Coverage Activity (V3) Example.xml
+++ b/Guide Examples/Coverage Activity (V3)_2.16.840.1.113883.10.20.22.4.60/Coverage Activity (V3) Example.xml
@@ -1,0 +1,16 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.60" extension="2015-08-01" />
+  <id root="1fe2cdd0-7aad-11db-9fe1-0800200c9a66" />
+  <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment sources" />
+  <statusCode code="completed" />
+  <entryRelationship typeCode="COMP">
+    <act classCode="ACT" moodCode="EVN">
+      <sequenceNumber value="2" />
+      <templateId root="2.16.840.1.113883.10.20.22.4.61" extension="2015-08-01" />
+            . . .
+        
+        
+        
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Coverage Activity (V3)_2.16.840.1.113883.10.20.22.4.60/README.md
+++ b/Guide Examples/Coverage Activity (V3)_2.16.840.1.113883.10.20.22.4.60/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Coverage Activity (V3)
+ 
+2.16.840.1.113883.10.20.22.4.60

--- a/Guide Examples/Criticality Observation _2.16.840.1.113883.10.20.22.4.145/Criticality Observation Example.xml
+++ b/Guide Examples/Criticality Observation _2.16.840.1.113883.10.20.22.4.145/Criticality Observation Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+  <code code="82606-5" codeSystem="2.16.840.1.113883.6.1" 
+               displayName="Criticality" />
+  <text>
+    <reference value="#criticality"/>
+  </text>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="High" displayName="High Criticality - NEED PROPER 
+               CODE" codeSystem="2.16.840.1.113883.6.96" 
+               codeSystemName="SNOMED CT"/>
+</observation>

--- a/Guide Examples/Criticality Observation _2.16.840.1.113883.10.20.22.4.145/README.md
+++ b/Guide Examples/Criticality Observation _2.16.840.1.113883.10.20.22.4.145/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Criticality Observation 
+ 
+2.16.840.1.113883.10.20.22.4.145

--- a/Guide Examples/Cultural and Religious Observation_2.16.840.1.113883.10.20.22.4.111/Cultural and Religious Observation Example.xml
+++ b/Guide Examples/Cultural and Religious Observation_2.16.840.1.113883.10.20.22.4.111/Cultural and Religious Observation Example.xml
@@ -1,0 +1,15 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- **Cultural and Religious Observation **-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.111" />
+    <id root="37f76c51-6411-4e1d-8a37-957fd49d2cef" />
+    <code code="75281-6" codeSystem="2.16.840.1.113883.6.1"
+                    displayName="Personal belief" />
+    <statusCode code="completed" />
+    <effectiveTime>
+      <low value="20130312" />
+    </effectiveTime>
+    <value xsi:type="ST">Does not accept blood transfusions, or donates, or
+            stores blood for transfusion.</value>
+  </observation>
+</entry>

--- a/Guide Examples/Cultural and Religious Observation_2.16.840.1.113883.10.20.22.4.111/README.md
+++ b/Guide Examples/Cultural and Religious Observation_2.16.840.1.113883.10.20.22.4.111/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Cultural and Religious Observation
+ 
+2.16.840.1.113883.10.20.22.4.111

--- a/Guide Examples/DICOM Object Catalog Section - DCM 121181_2.16.840.1.113883.10.20.6.1.1/DICOM Object Catalog Section - DCM 121181 Example.xml
+++ b/Guide Examples/DICOM Object Catalog Section - DCM 121181_2.16.840.1.113883.10.20.6.1.1/DICOM Object Catalog Section - DCM 121181 Example.xml
@@ -1,0 +1,48 @@
+<section classCode="DOCSECT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.1.1"/>
+  <code code="121181" 
+    codeSystem="1.2.840.10008.2.16.4"
+    codeSystemName="DCM" 
+    displayName="DICOM Object Catalog"/>
+  <entry>
+    <!-- **** Study Act **** -->
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.6.2.6"/>
+      <id root="1.2.840.113619.2.62.994044785528.114289542805"/>
+      <code code="113014"  
+        codeSystem="1.2.840.10008.2.16.4"
+        codeSystemName="DCM" 
+        displayName="Study"/>
+      <!-- **** Series Act****-->
+      <entryRelationship typeCode="COMP">
+        <act classCode="ACT" moodCode="EVN">
+          <id root="1.2.840.113619.2.62.994044785528.20060823223142485051"/>
+          <code code="113015" 
+            codeSystem="1.2.840.10008.2.16.4"
+            codeSystemName="DCM" 
+            displayName="Series">
+            ...
+          </code>
+          <!-- **** SOP Instance UID *** -->
+          <!-- 2 References -->
+          <entryRelationship typeCode="COMP">
+            <observation classCode="DGIMG" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.6.2.8"/>
+              ...
+              
+            
+            </observation>
+          </entryRelationship>
+          <entryRelationship typeCode="COMP">
+            <observation classCode="DGIMG" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.6.2.8"/>
+              ...
+              
+            
+            </observation>
+          </entryRelationship>
+        </act>
+      </entryRelationship>
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/DICOM Object Catalog Section - DCM 121181_2.16.840.1.113883.10.20.6.1.1/README.md
+++ b/Guide Examples/DICOM Object Catalog Section - DCM 121181_2.16.840.1.113883.10.20.6.1.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+DICOM Object Catalog Section - DCM 121181
+ 
+2.16.840.1.113883.10.20.6.1.1

--- a/Guide Examples/Deceased Observation (V3)_2.16.840.1.113883.10.20.22.4.79/Deceased Observation (V3) Example.xml
+++ b/Guide Examples/Deceased Observation (V3)_2.16.840.1.113883.10.20.22.4.79/Deceased Observation (V3) Example.xml
@@ -1,0 +1,20 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.79" extension="2015-08-01" />
+  <id root="6898fae0-5c8a-11db-b0de-0800200c9a77" />
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="20100303" />
+  </effectiveTime>
+  <value xsi:type="CD" code="419099009" codeSystem="2.16.840.1.113883.6.96" displayName="Dead" />
+  <entry typeCode="DRIV">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+        ...
+    
+        
+        
+        
+    </observation>
+  </entry>
+</observation>

--- a/Guide Examples/Deceased Observation (V3)_2.16.840.1.113883.10.20.22.4.79/README.md
+++ b/Guide Examples/Deceased Observation (V3)_2.16.840.1.113883.10.20.22.4.79/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Deceased Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.79

--- a/Guide Examples/Device Identifier Observation_2.16.840.1.113883.10.20.22.4.304/Device Identifier Example.xml
+++ b/Guide Examples/Device Identifier Observation_2.16.840.1.113883.10.20.22.4.304/Device Identifier Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.304" extension="2019-06-21"/>
+	<code code="C101722" displayName="Primary DI Number"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<!-- GS1 Device Identifier -->
+	<value xsi:type="II" root="1.3.160" extension="00999998998989" displayable="true"
+ assigningAuthorityName="GS1"/>
+</observation>

--- a/Guide Examples/Device Identifier Observation_2.16.840.1.113883.10.20.22.4.304/README.md
+++ b/Guide Examples/Device Identifier Observation_2.16.840.1.113883.10.20.22.4.304/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Device Identifier Observation
+ 
+2.16.840.1.113883.10.20.22.4.304

--- a/Guide Examples/Diagnostic Imaging Report (V3)_2.16.840.1.113883.10.20.22.1.5/DIR Participant Example.xml
+++ b/Guide Examples/Diagnostic Imaging Report (V3)_2.16.840.1.113883.10.20.22.1.5/DIR Participant Example.xml
@@ -1,0 +1,14 @@
+<participant typeCode="REF">
+  <associatedEntity classCode="PROV">
+    <id nullFlavor="NI" />
+    <addr nullFlavor="NI" />
+    <telecom nullFlavor="NI" />
+    <associatedPerson>
+      <name>
+        <given>Amanda</given>
+        <family>Assigned</family>
+        <suffix>MD</suffix>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Diagnostic Imaging Report (V3)_2.16.840.1.113883.10.20.22.1.5/README.md
+++ b/Guide Examples/Diagnostic Imaging Report (V3)_2.16.840.1.113883.10.20.22.1.5/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Diagnostic Imaging Report (V3)
+ 
+2.16.840.1.113883.10.20.22.1.5

--- a/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/Discharge Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/Discharge Diagnosis Section (V3) Example.xml
@@ -1,0 +1,22 @@
+<section>
+  <!-- Discharge Diagnosis Section Template Id -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.24" extension="2015-08-01" />
+  <code code="11535-2" displayName="Hospital Discharge Diagnosis"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+    <!-- Code being sought for Discharge Diagnosis - note: Concept will not be Prognosis -->
+    <translation code="C-CDAV2-DDN" displayName="Discharge Diagnosis"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+  </code>
+  <title>Discharge Diagnosis</title>
+  <text>Diverticula of intestine</text>
+  <entry>
+    <act classCode="ACT" moodCode="EVN">
+      <!-- Hospital discharge Diagnosis act -->
+            ...
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/README.md
+++ b/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Discharge Diagnosis Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.24

--- a/Guide Examples/Discharge Medication (V3)_2.16.840.1.113883.10.20.22.4.35/Discharge Medication (V3) Example.xml
+++ b/Guide Examples/Discharge Medication (V3)_2.16.840.1.113883.10.20.22.4.35/Discharge Medication (V3) Example.xml
@@ -1,0 +1,20 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.35" extension="2014-06-09" />
+  <code code="10183-2" 
+    displayName="Hospital discharge medication" 
+    codeSystem="2.16.840.1.113883.6.1" 
+    codeSystemName="LOINC">
+    <translation code="75311-1" 
+      displayName="Discharge medication" 
+      codeSystem="2.16.840.1.113883.6.1" 
+      codeSystemName="LOINC"/>
+  </code>
+  <statusCode code="completed" />
+  <entryRelationship typeCode="SUBJ">
+    <substanceAdministration classCode="SBADM" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+      ...
+    
+    </substanceAdministration>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Discharge Medication (V3)_2.16.840.1.113883.10.20.22.4.35/README.md
+++ b/Guide Examples/Discharge Medication (V3)_2.16.840.1.113883.10.20.22.4.35/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Discharge Medication (V3)
+ 
+2.16.840.1.113883.10.20.22.4.35

--- a/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge Medication Section (V3) (entries required) Example.xml
+++ b/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge Medication Section (V3) (entries required) Example.xml
@@ -1,0 +1,29 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.11.1" extension="2015-08-01" />
+  <code code="10183-2" displayName="Hospital Discharge Medications"
+                                codeSystem="2.16.840.1.113883.6.1"
+                                codeSystemName="LOINC">
+    <translation code="75311-1" displayName="Discharge Medications"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+  </code>
+  <title>Discharge Medications</title>
+  <text>
+       ...
+    </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="EVN">
+      <!-- Discharge Medication Entry -->
+            ...
+       
+        
+        
+        
+        
+    </act>
+  </entry>
+    ... 
+
+
+
+</section>

--- a/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/README.md
+++ b/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Discharge Medications Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.11.1

--- a/Guide Examples/Discharge Summary (V3)_2.16.840.1.113883.10.20.22.1.8/Discharge Summary encompassingEncounter Example.xml
+++ b/Guide Examples/Discharge Summary (V3)_2.16.840.1.113883.10.20.22.1.8/Discharge Summary encompassingEncounter Example.xml
@@ -1,0 +1,16 @@
+<componentOf>
+  <encompassingEncounter>
+    <id extension="9937012" root="2.16.840.1.113883.19" />
+    <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" displayName="Evaluation and Management" />
+    <effectiveTime>
+      <low value="20090227130000+0500" />
+      <high value="20090227130000+0500" />
+    </effectiveTime>
+    <dischargeDispositionCode code="01" codeSystem="2.16.840.1.113883.12.112" displayName="Routine Discharge" codeSystemName="HL7 Discharge Disposition" />
+    <location>
+      <healthCareFacility>
+        <id root="2.16.540.1.113883.19.2" />
+      </healthCareFacility>
+    </location>
+  </encompassingEncounter>
+</componentOf>

--- a/Guide Examples/Discharge Summary (V3)_2.16.840.1.113883.10.20.22.1.8/README.md
+++ b/Guide Examples/Discharge Summary (V3)_2.16.840.1.113883.10.20.22.1.8/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Discharge Summary (V3)
+ 
+2.16.840.1.113883.10.20.22.1.8

--- a/Guide Examples/Distinct Identification Code Observation_2.16.840.1.113883.10.20.22.4.308/Distinct Identification Code Example.xml
+++ b/Guide Examples/Distinct Identification Code Observation_2.16.840.1.113883.10.20.22.4.308/Distinct Identification Code Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.308" extension="2019-06-21"/>
+	<code code="C113843" displayName="Distinct Identification Code"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#DistinctIdentificationCode_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Distinct Identification Code Observation_2.16.840.1.113883.10.20.22.4.308/README.md
+++ b/Guide Examples/Distinct Identification Code Observation_2.16.840.1.113883.10.20.22.4.308/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Distinct Identification Code Observation
+ 
+2.16.840.1.113883.10.20.22.4.308

--- a/Guide Examples/Drug Monitoring Act_2.16.840.1.113883.10.20.22.4.123/Drug Monitoring Act Example.xml
+++ b/Guide Examples/Drug Monitoring Act_2.16.840.1.113883.10.20.22.4.123/Drug Monitoring Act Example.xml
@@ -1,0 +1,25 @@
+<entryRelationship typeCode="COMP">
+  <!-- **DRUG MONITORING ACT **-->
+  <act classCode="ACT" moodCode="INT">
+    <templateId root="2.16.840.1.113883.10.20.22.4.123" />
+    <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
+    <code code="395170001" displayName="medication monitoring(regime/therapy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <statusCode code="completed" />
+    <effectiveTime xsi:type="IVL_TS">
+      <low value="20130615" />
+      <high value="20130715" />
+    </effectiveTime>
+    <participant typeCode="RESP">
+      <participantRole classCode="ASSIGNED">
+        <id root="2a620155-9d11-439e-92b3-5d9815ff4ee5" />
+        <playingEntity classCode="PSN">
+          <name>
+            <given>Listener</given>
+            <family>Larry</family>
+            <prefix>DR</prefix>
+          </name>
+        </playingEntity>
+      </participantRole>
+    </participant>
+  </act>
+</entryRelationship>

--- a/Guide Examples/Drug Monitoring Act_2.16.840.1.113883.10.20.22.4.123/README.md
+++ b/Guide Examples/Drug Monitoring Act_2.16.840.1.113883.10.20.22.4.123/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Drug Monitoring Act
+ 
+2.16.840.1.113883.10.20.22.4.123

--- a/Guide Examples/Drug Vehicle_2.16.840.1.113883.10.20.22.4.24/Drug Vehicle Example.xml
+++ b/Guide Examples/Drug Vehicle_2.16.840.1.113883.10.20.22.4.24/Drug Vehicle Example.xml
@@ -1,0 +1,11 @@
+<participantRole classCode="MANU">
+  <templateId root="2.16.840.1.113883.10.20.22.4.24"/>
+  <code code="412307009" displayName="drug vehicle"
+	codeSystem="2.16.840.1.113883.6.96"/>
+  <playingEntity classCode="MMAT">
+    <code code="324049" displayName="Aerosol"
+		codeSystem="2.16.840.1.113883.6.88"
+		codeSystemName="RxNorm"/>
+    <name>Aerosol</name>
+  </playingEntity>
+</participantRole>

--- a/Guide Examples/Drug Vehicle_2.16.840.1.113883.10.20.22.4.24/README.md
+++ b/Guide Examples/Drug Vehicle_2.16.840.1.113883.10.20.22.4.24/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Drug Vehicle
+ 
+2.16.840.1.113883.10.20.22.4.24

--- a/Guide Examples/Encounter Activity (V3)_2.16.840.1.113883.10.20.22.4.49/Encounter Activity (V3) Example.xml
+++ b/Guide Examples/Encounter Activity (V3)_2.16.840.1.113883.10.20.22.4.49/Encounter Activity (V3) Example.xml
@@ -1,0 +1,32 @@
+<encounter classCode="ENC" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
+  <id root="2a620155-9d11-439e-92b3-5d9815ff4de8" />
+  <code code="99213" displayName="Office outpatient visit 15 minutes" codeSystemName="CPT-4" codeSystem="2.16.840.1.113883.6.12">
+    <originalText>
+      <reference value="#Encounter1" />
+    </originalText>
+    <translation code="AMB" codeSystem="2.16.840.1.113883.5.4" displayName="Ambulatory" codeSystemName="HL7 ActEncounterCode" />
+  </code>
+  <effectiveTime value="201209271300+0500" />
+  <performer>
+    <assignedEntity>
+        . . .
+        </assignedEntity>
+  </performer>
+  <participant typeCode="LOC">
+    <participantRole classCode="SDLOC">
+      <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+            
+            . . .
+        
+    </participantRole>
+  </participant>
+  <entryRelationship typeCode="RSON">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+            
+            . . .
+        
+    </observation>
+  </entryRelationship>
+</encounter>

--- a/Guide Examples/Encounter Activity (V3)_2.16.840.1.113883.10.20.22.4.49/README.md
+++ b/Guide Examples/Encounter Activity (V3)_2.16.840.1.113883.10.20.22.4.49/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Encounter Activity (V3)
+ 
+2.16.840.1.113883.10.20.22.4.49

--- a/Guide Examples/Encounter Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.80/Encounter Diagnosis (V3) Example.xml
+++ b/Guide Examples/Encounter Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.80/Encounter Diagnosis (V3) Example.xml
@@ -1,0 +1,19 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.80" extension="2015-08-01" />
+  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=" DIAGNOSIS" />
+  <statusCode code="active" />
+  <effectiveTime>
+    <low value="20903003" />
+  </effectiveTime>
+  <entryRelationship typeCode="SUBJ">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      <!-- Problem Observation -->
+          ...
+      
+        
+        
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Encounter Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.80/README.md
+++ b/Guide Examples/Encounter Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.80/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Encounter Diagnosis (V3)
+ 
+2.16.840.1.113883.10.20.22.4.80

--- a/Guide Examples/Encounters Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.22.1/Encounters Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Encounters Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.22.1/Encounters Section (entries required) (V3) Example.xml
@@ -1,0 +1,17 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.22.1" extension="2015-08-01" />
+  <!-- Encounters Section - Entries required -->
+  <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of encounters" />
+  <title>Encounters</title>
+  <text>
+    ...
+  </text>
+  <entry typeCode="DRIV">
+    <encounter classCode="ENC" moodCode="EVN">
+      <!-- Encounter Activities -->
+            ...
+        
+        
+    </encounter>
+  </entry>
+</section>

--- a/Guide Examples/Encounters Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.22.1/README.md
+++ b/Guide Examples/Encounters Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.22.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Encounters Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.22.1

--- a/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis Reference Example.xml
+++ b/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis Reference Example.xml
@@ -1,0 +1,28 @@
+<!-- Show how an encounter can include a discharge diagnosis which references an 
+       item on the problem list using the Entry Reference template -->
+<!-- Problem Section -->
+<observation>
+  <id root="1234567" />
+  <code code="123" codeSystem="1.2.3" displayName="asthma" />
+</observation>
+<!-- Encounter Section -->
+<encounter>
+  <entryRelationship typeCode="COMP">
+    <act>
+      <code code="145" codeSystem="4.5.6" displayName="discharge diagnosis" />
+      <templateId root="2.16.840.1.113883.10.20.22.4.33" extension="2014-06-09" />
+      <!-- this is for illustrative purposes only. In this particular 
+                  case, the template requires a nested Problem 
+                  Observation (V2). In the Health Concern template, 
+                  we'd need a constraint that says it's allowable to 
+                  include the Entry Reference template. -->
+      <entryRelationship typeCode="SUBJ">
+        <act classCode="ACT" moodCode="XXX">
+          <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+          <id root="1234567" />
+          <code nullFlavor="NP" />
+        </act>
+      </entryRelationship>
+    </act>
+  </entryRelationship>
+</encounter>

--- a/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Entry Reference Example.xml
+++ b/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Entry Reference Example.xml
@@ -1,0 +1,81 @@
+<!-- 
+  ********************************************************
+  Health Concern section
+  ********************************************************
+-->
+<act classCode="ACT" moodCode="EVN">
+  <!-- Health Concern Act of a pneumonia diagnosis -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.132" />
+  <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
+  <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern" />
+  <statusCode code="active" />
+  <effectiveTime value="20130616" />
+  <entryRelationship typeCode="REFR">
+    <!-- Problem Observation (V2) -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2014-06-09" />
+      <id root="8dfacd73-1682-4cc4-9351-e54ccea83612" />
+      <code code="29308-4" 
+            codeSystem="2.16.840.1.113883.6.1" 
+            codeSystemName="LOINC" 
+            displayName="Diagnosis"/>
+      <statusCode code="completed" />
+      <effectiveTime>
+        <!-- Date of diagnosis -->
+        <low value="20130616" />
+      </effectiveTime>
+      <value xsi:type="CD" code="233604007" 
+            codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED" 
+            displayName="Pneumonia" />
+      <!-- This Entry Reference refers to a goal, intervention, actual 
+         outcome, or some other entry present in the Care Plan
+         that the Health Concern is related to-->
+      <entryRelationship typeCode="REFR">
+        <act classCode="ACT" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+          <!-- This ID equals the ID of the goal of a pulse 
+                        ox greater than 92% -->
+          <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+          <!-- The code is nulled to "NP" Not Present" -->
+          <code nullFlavor="NP" />
+          <statusCode code="completed" />
+        </act>
+      </entryRelationship>
+    </observation>
+  </entryRelationship>
+</act>
+
+...
+
+
+<!-- 
+  ********************************************************
+  Expected Outcomes/Goals section
+  ********************************************************
+-->
+
+...
+
+
+<entry>
+  <!-- This is an observation about the expected outcome of a pulse ox reading
+       of 92 or greater.  The Id is the same as the ID as the ID of the 
+       pneumonia problem above  -->
+  <observation classCode="OBS" moodCode="GOL">
+    <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+    <code code="59408-5" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="Oxygen saturation in Arterial blood by Pulse oximetry"/>
+    <statusCode code="active" />
+    <value xsi:type="IVL_PQ">
+      <low value="92" unit="%" />
+    </value>
+    <!-- There could be another Entry Reference here referring to the 
+            related health concern, actual outcome, or intervention -->
+    ...
+    
+  
+  </observation>
+</entry>
+...

--- a/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/README.md
+++ b/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Entry Reference
+ 
+2.16.840.1.113883.10.20.22.4.122

--- a/Guide Examples/Estimated Date of Delivery_2.16.840.1.113883.10.20.15.3.1/Estimated Date of Delivery Example.xml
+++ b/Guide Examples/Estimated Date of Delivery_2.16.840.1.113883.10.20.15.3.1/Estimated Date of Delivery Example.xml
@@ -1,0 +1,7 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.15.3.1"/>
+  <code code="11778-8" codeSystem="2.16.840.1.113883.6.1" 
+        displayName="Estimated date of delivery"/>
+  <statusCode code="completed"/>
+  <value xsi:type="TS" value="20110919" />
+</observation>

--- a/Guide Examples/Estimated Date of Delivery_2.16.840.1.113883.10.20.15.3.1/README.md
+++ b/Guide Examples/Estimated Date of Delivery_2.16.840.1.113883.10.20.15.3.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Estimated Date of Delivery
+ 
+2.16.840.1.113883.10.20.15.3.1

--- a/Guide Examples/Expiration Date Observation_2.16.840.1.113883.10.20.22.4.309/Expiration Date Example.xml
+++ b/Guide Examples/Expiration Date Observation_2.16.840.1.113883.10.20.22.4.309/Expiration Date Example.xml
@@ -1,0 +1,6 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.309" extension="2019-06-21"/>
+	<code code="C101670" displayName="Expiration Date"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="TS" value="20221015"/>
+</observation>

--- a/Guide Examples/Expiration Date Observation_2.16.840.1.113883.10.20.22.4.309/README.md
+++ b/Guide Examples/Expiration Date Observation_2.16.840.1.113883.10.20.22.4.309/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Expiration Date Observation
+ 
+2.16.840.1.113883.10.20.22.4.309

--- a/Guide Examples/External Document Reference_2.16.840.1.113883.10.20.22.4.115/External Document Reference Example.xml
+++ b/Guide Examples/External Document Reference_2.16.840.1.113883.10.20.22.4.115/External Document Reference Example.xml
@@ -1,0 +1,11 @@
+<externalDocument classCode="DOCCLIN" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.115" 
+        extension="2014-06-09" />
+  <id root="6f1bd58b-c58f-40b7-b314-caf1294ed98b" />
+  <code codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        code="57133-1"
+        displayName="Referral Note" />
+  <setId extension="sTT988" root="2.16.840.1.113883.19.5.99999.19" />
+  <versionNumber value="1" />
+</externalDocument>

--- a/Guide Examples/External Document Reference_2.16.840.1.113883.10.20.22.4.115/README.md
+++ b/Guide Examples/External Document Reference_2.16.840.1.113883.10.20.22.4.115/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+External Document Reference
+ 
+2.16.840.1.113883.10.20.22.4.115

--- a/Guide Examples/Family History Death Observation_2.16.840.1.113883.10.20.22.4.47/Family History Death Observation Example.xml
+++ b/Guide Examples/Family History Death Observation_2.16.840.1.113883.10.20.22.4.47/Family History Death Observation Example.xml
@@ -1,0 +1,10 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.47"/>
+  <id root="6898fae0-5c8a-11db-b0de-0800200c9a66"/>
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" 
+        code="419099009" 
+        codeSystem="2.16.840.1.113883.6.96"
+        displayName="Dead"/>
+</observation>

--- a/Guide Examples/Family History Death Observation_2.16.840.1.113883.10.20.22.4.47/README.md
+++ b/Guide Examples/Family History Death Observation_2.16.840.1.113883.10.20.22.4.47/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Family History Death Observation
+ 
+2.16.840.1.113883.10.20.22.4.47

--- a/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/Family History Observation (V3) Example.xml
+++ b/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/Family History Observation (V3) Example.xml
@@ -1,0 +1,31 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01" />
+  <!-- Family History Observation template -->
+  <id root="d42ebf70-5c89-11db-b0de-0800200c9a66" />
+  <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition">
+    <translation code="64572001" displayName="Condition" 
+                                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></translation>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime value="1967" />
+  <value xsi:type="CD" code="22298006" codeSystem="2.16.840.1.113883.6.96" displayName="Myocardial infarction" />
+  <entryRelationship typeCode="CAUS">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.47" />
+			
+              ...
+				
+        
+        
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.31" />					
+             ....
+   	   
+        
+        
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/README.md
+++ b/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Family History Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.46

--- a/Guide Examples/Family History Organizer (V3)_2.16.840.1.113883.10.20.22.4.45/Family History Organizer (V3) Example.xml
+++ b/Guide Examples/Family History Organizer (V3)_2.16.840.1.113883.10.20.22.4.45/Family History Organizer (V3) Example.xml
@@ -1,0 +1,29 @@
+<organizer moodCode="EVN" classCode="CLUSTER">
+  <templateId root="2.16.840.1.113883.10.20.22.4.45" extension="2015-08-01" />
+  <statusCode code="completed" />
+  <subject>
+    <relatedSubject classCode="PRS">
+      <code code="FTH" displayName="Father" codeSystemName="HL7 FamilyMember" codeSystem="2.16.840.1.113883.5.111">
+        <translation code="9947008" displayName="Natural father" codeSystemName="SNOMED" codeSystem="2.16.840.1.113883.6.96" />
+      </code>
+      <subject>
+        <sdtc:id root="2.16.840.1.113883.19.5.99999.2" extension="99999999" />
+        <id root="2.16.840.1.113883.19.5.99999.2" extension="1234" />
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" />
+        <birthTime value="1910" />
+        <!-- Example use of sdtc extensions :-->
+        <!-- <sdtc:deceasedInd value="true"/><sdtc:deceasedTime value="1967"/> 
+                -->
+      </subject>
+    </relatedSubject>
+  </subject>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01" />
+            . . .
+       
+        
+        
+    </observation>
+  </component>
+</organizer>

--- a/Guide Examples/Family History Organizer (V3)_2.16.840.1.113883.10.20.22.4.45/README.md
+++ b/Guide Examples/Family History Organizer (V3)_2.16.840.1.113883.10.20.22.4.45/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Family History Organizer (V3)
+ 
+2.16.840.1.113883.10.20.22.4.45

--- a/Guide Examples/Family History Section (V3)_2.16.840.1.113883.10.20.22.2.15/Family History Section (V3) Example.xml
+++ b/Guide Examples/Family History Section (V3)_2.16.840.1.113883.10.20.22.2.15/Family History Section (V3) Example.xml
@@ -1,0 +1,19 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01" />
+  <!--  Family history section template  -->
+  <code code="10157-6" codeSystem="2.16.840.1.113883.6.1" />
+  <title>Family history</title>
+  <text>
+    ...
+  </text>
+  <entry typeCode="DRIV">
+    <organizer moodCode="EVN" classCode="CLUSTER">
+      <templateId root="2.16.840.1.113883.10.20.22.4.45" />
+      <!--    Family history organizer template   -->
+       ...
+    
+        
+        
+    </organizer>
+  </entry>
+</section>

--- a/Guide Examples/Family History Section (V3)_2.16.840.1.113883.10.20.22.2.15/README.md
+++ b/Guide Examples/Family History Section (V3)_2.16.840.1.113883.10.20.22.2.15/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Family History Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.15

--- a/Guide Examples/Fetus Subject Context_2.16.840.1.113883.10.20.6.2.3/Fetus Subject Context Example.xml
+++ b/Guide Examples/Fetus Subject Context_2.16.840.1.113883.10.20.6.2.3/Fetus Subject Context Example.xml
@@ -1,0 +1,9 @@
+<relatedSubject>
+  <templateId root="2.16.840.1.113883.10.20.6.2.3"/>
+  <code code="121026"
+        codeSystem="1.2.840.10008.2.16.4"
+        displayName="Fetus"/>
+  <subject>
+    <name>fetus_1</name>
+  </subject>
+</relatedSubject>

--- a/Guide Examples/Fetus Subject Context_2.16.840.1.113883.10.20.6.2.3/README.md
+++ b/Guide Examples/Fetus Subject Context_2.16.840.1.113883.10.20.6.2.3/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Fetus Subject Context
+ 
+2.16.840.1.113883.10.20.6.2.3

--- a/Guide Examples/Findings Section (DIR)_2.16.840.1.113883.10.20.6.1.2/Findings Section (DIR) Example.xml
+++ b/Guide Examples/Findings Section (DIR)_2.16.840.1.113883.10.20.6.1.2/Findings Section (DIR) Example.xml
@@ -1,0 +1,27 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.6.1.2"/>
+  <code code="121070" 	
+          codeSystem="1.2.840.10008.2.16.4" 
+          codeSystemName="DCM" 
+          displayName="Findings"/>
+  <title>Findings</title>
+  <text>
+    <paragraph>
+      <caption>Finding</caption>
+      <content ID="Fndng2">The cardiomediastinum is     . </content>
+    </paragraph>
+    <paragraph>
+      <caption>Diameter</caption>
+      <content ID="Diam2">45mm</content>
+    </paragraph>
+       ...
+    
+    
+  </text>
+  <entry>
+    <templateId root="2.16.840.1.113883.10.20.6.2.12"/>
+       ...
+    
+    
+  </entry>
+</section>

--- a/Guide Examples/Findings Section (DIR)_2.16.840.1.113883.10.20.6.1.2/README.md
+++ b/Guide Examples/Findings Section (DIR)_2.16.840.1.113883.10.20.6.1.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Findings Section (DIR)
+ 
+2.16.840.1.113883.10.20.6.1.2

--- a/Guide Examples/Functional Status Observation (V2)_2.16.840.1.113883.10.20.22.4.67/Functional Status Observation (V2) Example.xml
+++ b/Guide Examples/Functional Status Observation (V2)_2.16.840.1.113883.10.20.22.4.67/Functional Status Observation (V2) Example.xml
@@ -1,0 +1,14 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Functional Status Observation V2-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.67" extension="2014-06-09" />
+    <id root="ce7cfb78-bd16-467e-8bcf-859a3034108e" />
+    <code code="54522-8" displayName="Functional status" codeSystem="2.16.840.1.113883.6.1" codeSystemName="SNOMED CT" />
+    <text>
+      <reference value="#FUNC1" />
+    </text>
+    <statusCode code="completed" />
+    <effectiveTime value="200130311" />
+    <value xsi:type="CD" code="129035000" displayName="independent with dressing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  </observation>
+</entry>

--- a/Guide Examples/Functional Status Observation (V2)_2.16.840.1.113883.10.20.22.4.67/README.md
+++ b/Guide Examples/Functional Status Observation (V2)_2.16.840.1.113883.10.20.22.4.67/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Functional Status Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.67

--- a/Guide Examples/Functional Status Organizer (V2)_2.16.840.1.113883.10.20.22.4.66/Functional Status Organizer (V2) Example.xml
+++ b/Guide Examples/Functional Status Organizer (V2)_2.16.840.1.113883.10.20.22.4.66/Functional Status Organizer (V2) Example.xml
@@ -1,0 +1,52 @@
+<organizer classCode="CLUSTER" moodCode="EVN">
+  <!-- Functional Status Organizer V2-->
+  <templateId root="2.16.840.1.113883.10.20.22.4.66" extension="2014-06-09" />
+  <id root="a7bc1062-8649-42a0-833d-eed65bd017c9" />
+  <code code="d5" displayName="Self-Care" codeSystem="2.16.840.1.113883.6.254" codeSystemName="ICF" />
+  <statusCode code="completed" />
+  <author>
+    <time value="200130311" />
+    <assignedAuthor>
+      <id extension="KP00017" root="2.16.840.1.113883.19.5" />
+      <addr>
+        <streetAddressLine>1003 Health Care
+                    Drive</streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(555)555-1003" />
+      <assignedPerson>
+        <name>
+          <given>Assigned</given>
+          <family>Amanda</family>
+        </name>
+      </assignedPerson>
+    </assignedAuthor>
+  </author>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Functional Status Observation V2-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.67" extension="2014-06-09" />
+            ...
+        
+    </observation>
+  </component>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Functional Status Observation V2-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.67" extension="2014-06-09" />
+            ...
+        
+    </observation>
+  </component>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Self-Care Activities (ADL and IADL)-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.128" />
+            ...
+        
+    </observation>
+  </component>
+</organizer>

--- a/Guide Examples/Functional Status Organizer (V2)_2.16.840.1.113883.10.20.22.4.66/README.md
+++ b/Guide Examples/Functional Status Organizer (V2)_2.16.840.1.113883.10.20.22.4.66/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Functional Status Organizer (V2)
+ 
+2.16.840.1.113883.10.20.22.4.66

--- a/Guide Examples/Functional Status Section (V2)_2.16.840.1.113883.10.20.22.2.14/Functional Status Section (V2) Example.xml
+++ b/Guide Examples/Functional Status Section (V2)_2.16.840.1.113883.10.20.22.2.14/Functional Status Section (V2) Example.xml
@@ -1,0 +1,50 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09" />
+  <!-- Functional Status Section template V2-->
+  <code code="47420-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Functional Status" />
+  <title>FUNCTIONAL STATUS</title>
+  <text>
+        ...
+    </text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Self Care Activities (NEW)-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.128" />
+            ...
+        
+    </observation>
+  </entry>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Sensory and Speech Status(NEW)-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.127" />
+            ...
+        
+    </observation>
+  </entry>
+  <entry>
+    <organizer classCode="CLUSTER" moodCode="EVN">
+      <!-- Functional Status Organizer V2-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.66" extension="2014-06-09" />
+            ....
+        
+    </organizer>
+  </entry>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Functional Status  Observation V2-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.67" extension="2014-06-09" />           
+            ...
+        
+    </observation>
+  </entry>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Caregiver characteristics ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.72" />
+           
+            ...
+        
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Functional Status Section (V2)_2.16.840.1.113883.10.20.22.2.14/README.md
+++ b/Guide Examples/Functional Status Section (V2)_2.16.840.1.113883.10.20.22.2.14/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Functional Status Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.14

--- a/Guide Examples/General Status Section_2.16.840.1.113883.10.20.2.5/General Status Section Example.xml
+++ b/Guide Examples/General Status Section_2.16.840.1.113883.10.20.2.5/General Status Section Example.xml
@@ -1,0 +1,12 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.2.5" />
+  <code code="10210-3" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="GENERAL STATUS" />
+  <title>GENERAL STATUS</title>
+  <text>
+    <paragraph>Alert and in good spirits, no acute distress.
+       </paragraph>
+  </text>
+</section>

--- a/Guide Examples/General Status Section_2.16.840.1.113883.10.20.2.5/README.md
+++ b/Guide Examples/General Status Section_2.16.840.1.113883.10.20.2.5/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+General Status Section
+ 
+2.16.840.1.113883.10.20.2.5

--- a/Guide Examples/Goal Observation_2.16.840.1.113883.10.20.22.4.121/Goal Observation Example.xml
+++ b/Guide Examples/Goal Observation_2.16.840.1.113883.10.20.22.4.121/Goal Observation Example.xml
@@ -1,0 +1,63 @@
+<observation classCode="OBS" moodCode="GOL">
+  <templateId root="2.16.840.1.113883.10.20.22.4.121" />
+  <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+  <code code="59408-5" 
+        codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Oxygen saturation in Arterial blood by Pulse oximetry" />
+  <statusCode code="active" />
+  <effectiveTime value="20130902" />
+  <value xsi:type="IVL_PQ">
+    <low value="92" unit="%" />
+  </value>
+  <!--
+    If the author is set to the recordTarget (patient), this is a patient goal.  
+    If the author is set to a provider, this is a provider goal. 
+    If both patient and provider are set as authors, this is a negotiated goal.
+  -->
+  <!-- Provider Author -->
+  <author>
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    ...
+  
+  </author>
+  <!-- Patient Author -->
+  <author typeCode="AUT">
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    ...
+  
+  </author>
+  <!-- This entryRelationship represents the relationship "Goal REFERS TO Health Concern" -->
+  <entryRelationship typeCode="REFR">
+    <!-- Entry Reference Concern Act -->
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+      <!-- This id points to an already defined Health Concern in the Health Concerns Section -->
+      <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
+      ...
+    
+    </act>
+  </entryRelationship>
+  <!-- Priority Preference -->
+  <entryRelationship typeCode="RSON">
+    <!-- Priority Preference - this is the preference that the patient 
+      (specified by the Author Participation template)
+                  places on the Goal -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+      ...
+    
+    </observation>
+  </entryRelationship>
+  <!--  Priority Preference - this is the preference that the provider 
+    (specified by the Author Participation template)
+     places on the Goal -->
+  <entryRelationship typeCode="RSON">
+    <!--  Priority Preference -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+      ...
+    
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Goal Observation_2.16.840.1.113883.10.20.22.4.121/README.md
+++ b/Guide Examples/Goal Observation_2.16.840.1.113883.10.20.22.4.121/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Goal Observation
+ 
+2.16.840.1.113883.10.20.22.4.121

--- a/Guide Examples/Goals Section_2.16.840.1.113883.10.20.22.2.60/Goals Section Example.xml
+++ b/Guide Examples/Goals Section_2.16.840.1.113883.10.20.22.2.60/Goals Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.60" />
+  <code code="61146-7" displayName="Goals" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <title>Goals Section</title>
+  <text />
+  <entry>
+    <observation />
+  </entry>
+</section>

--- a/Guide Examples/Goals Section_2.16.840.1.113883.10.20.22.2.60/README.md
+++ b/Guide Examples/Goals Section_2.16.840.1.113883.10.20.22.2.60/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Goals Section
+ 
+2.16.840.1.113883.10.20.22.2.60

--- a/Guide Examples/Handoff Communication Participants_2.16.840.1.113883.10.20.22.4.141/Handoff Communication Example.xml
+++ b/Guide Examples/Handoff Communication Participants_2.16.840.1.113883.10.20.22.4.141/Handoff Communication Example.xml
@@ -1,0 +1,24 @@
+<entry>
+  <act classCode="ACT" moodCode="EVN">
+    <templateId root="2.16.840.1.113883.10.20.22.4.141" />
+    <code code="432138007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="handoff communication (procedure)" />
+    <statusCode code="completed" />
+    <effectiveTime value="20130712" />
+    <author typeCode="AUT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+      <time value="20130730" />
+      <assignedAuthor>
+        <id root="d839038b-7171-4165-a760-467925b43857" />
+              ...
+            
+      </assignedAuthor>
+    </author>
+    <participant typeCode="IRCP">
+      <participantRole>
+        <code code="163W00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC Health Care Provider Taxonomy" displayName="Registered Nurse" />
+                ...
+            
+      </participantRole>
+    </participant>
+  </act>
+</entry>

--- a/Guide Examples/Handoff Communication Participants_2.16.840.1.113883.10.20.22.4.141/README.md
+++ b/Guide Examples/Handoff Communication Participants_2.16.840.1.113883.10.20.22.4.141/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Handoff Communication Participants
+ 
+2.16.840.1.113883.10.20.22.4.141

--- a/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/Health Concern Act Example.xml
+++ b/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/Health Concern Act Example.xml
@@ -1,0 +1,83 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.132" extension=�2015-08-01� />
+  <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
+  <code code="75310-3" 
+        codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Health Concern" />
+  <!-- This Health Concern has a statusCode of active because it is an active concern -->
+  <statusCode code="active" />
+  <!-- The effective time is the date that the Health Concern started being followed - 
+     this does not necessarily correlate to the onset date of the contained health issues-->
+  <effectiveTime value="20130616" />
+  <!-- Health Concern: Current every day smoker-->
+  <entryRelationship typeCode="REFR">
+    <!-- Tobacco Use (V2) -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.85" extension="2014-06-09" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+  <!-- Health Concern Problem: Respiratory insufficiency -->
+  <entryRelationship typeCode="REFR">
+    <!-- Problem Observation (V2) -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+  <!-- Health Concern Diagnosis: Pneumonia -->
+  <entryRelationship typeCode="REFR">
+    <!-- Problem Observation (V2) -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+  <!-- 
+        This is an entry relationship of the SPRT (support) type which shows 
+        that the productive cough supports the Health Concern (Problem: Respiratory 
+        Insufficiency and Diagnosis: Pneumonia
+        This entryRelationship represents the relationship: 
+         Health Concern HAS SUPPORT Observation
+       -->
+  <entryRelationship typeCode="SPRT">
+    <!-- Problem Observation (V2) -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+  <!-- Priority Preference -->
+  <entryRelationship typeCode="RSON">
+    <!-- Priority Preference - this is the preference that the patient 
+      (specified by the Author Participation template)
+       places on the Health Concern -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+  <!--  Priority Preference - this is the preference that the provider 
+    (specified by the Author Participation template)
+     places on the Health Concern -->
+  <entryRelationship typeCode="RSON">
+    <!--  Priority Preference -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+      ...
+    
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/README.md
+++ b/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Health Concern Act (V2)
+ 
+2.16.840.1.113883.10.20.22.4.132

--- a/Guide Examples/Health Concerns Section (V2)_2.16.840.1.113883.10.20.22.2.58/Health Concerns Section Example.xml
+++ b/Guide Examples/Health Concerns Section (V2)_2.16.840.1.113883.10.20.22.2.58/Health Concerns Section Example.xml
@@ -1,0 +1,14 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.58" />
+  <code code="75310-3" displayName="Health Concerns Document" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <title>Health Concerns Section</title>
+  <text>
+      ...
+    </text>
+  <entry>
+    <!-- Health Status Observation -->
+  </entry>
+  <entry>
+    <!-- Health Concern Act -->
+  </entry>
+</section>

--- a/Guide Examples/Health Concerns Section (V2)_2.16.840.1.113883.10.20.22.2.58/README.md
+++ b/Guide Examples/Health Concerns Section (V2)_2.16.840.1.113883.10.20.22.2.58/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Health Concerns Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.58

--- a/Guide Examples/Health Status Evaluations and Outcomes Section_2.16.840.1.113883.10.20.22.2.61/Health Status Evaluations and Outcomes Section Example.xml
+++ b/Guide Examples/Health Status Evaluations and Outcomes Section_2.16.840.1.113883.10.20.22.2.61/Health Status Evaluations and Outcomes Section Example.xml
@@ -1,0 +1,36 @@
+<section>
+  <!-- Health Status Evaluations/Outcomes Section  -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.61" />
+  <code code="11383-7" displayName="Patient Problem Outcome" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <title>Health Status Evaluations/Outcomes Section</title>
+  <text>
+    <list>
+      <item>
+        <content styleCode="Bold">Pulse oximetry greater than 92% on room air</content>: MET 
+        <list>
+          <item>Evaluates Expected Outcome/Goal: 
+            
+            <content styleCode="Bold">
+              Pulse oximetry greater than 92% on room air
+            </content>
+          </item>
+          <item>Supported by: Pulse oximetry 95% on room air (March 21, 2013 at 15:20)</item>
+        </list>
+      </item>
+    </list>
+  </text>
+  <entry>
+    <!-- Outcome Observation -->
+    <observation classCode="OBS" moodCode="EVN">
+      ...
+    </observation>
+  </entry>
+  <entry>
+    <!-- Outcome Observation -->
+    <observation classCode="OBS" moodCode="EVN">
+      ...
+    </observation>
+  </entry>
+  ...
+
+</section>

--- a/Guide Examples/Health Status Evaluations and Outcomes Section_2.16.840.1.113883.10.20.22.2.61/README.md
+++ b/Guide Examples/Health Status Evaluations and Outcomes Section_2.16.840.1.113883.10.20.22.2.61/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Health Status Evaluations and Outcomes Section
+ 
+2.16.840.1.113883.10.20.22.2.61

--- a/Guide Examples/Health Status Observation (V2)_2.16.840.1.113883.10.20.22.4.5/Health Status Observation (V2) Example.xml
+++ b/Guide Examples/Health Status Observation (V2)_2.16.840.1.113883.10.20.22.4.5/Health Status Observation (V2) Example.xml
@@ -1,0 +1,9 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+  <code code="11323-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health status" />
+  <text>
+    <reference value="#healthstatus" />
+  </text>
+  <statusCode code="completed" />
+  <value xsi:type="CD" code="81323004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Alive and well" />
+</observation>

--- a/Guide Examples/Health Status Observation (V2)_2.16.840.1.113883.10.20.22.4.5/README.md
+++ b/Guide Examples/Health Status Observation (V2)_2.16.840.1.113883.10.20.22.4.5/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Health Status Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.5

--- a/Guide Examples/Highest Pressure Ulcer Stage_2.16.840.1.113883.10.20.22.4.77/Highest Pressure Ulcer Stage Example.xml
+++ b/Guide Examples/Highest Pressure Ulcer Stage_2.16.840.1.113883.10.20.22.4.77/Highest Pressure Ulcer Stage Example.xml
@@ -1,0 +1,10 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.77"/>
+  <id root="08edb7c0-2111-43f2-a784-9a5fdfaa67f0"/>
+  <code code="420905001" codeSystem="2.16.840.1.113883.6.96"
+        displayName=" Highest Pressure Ulcer Stage"/>
+  <statusCode code="completed"/>
+  <value xsi:type="CD" code="421306004"
+         codeSystem="2.16.840.1.113883.6.96" 
+         displayName="necrotic eschar"/>
+</observation>

--- a/Guide Examples/Highest Pressure Ulcer Stage_2.16.840.1.113883.10.20.22.4.77/README.md
+++ b/Guide Examples/Highest Pressure Ulcer Stage_2.16.840.1.113883.10.20.22.4.77/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Highest Pressure Ulcer Stage
+ 
+2.16.840.1.113883.10.20.22.4.77

--- a/Guide Examples/History and Physical (V3)_2.16.840.1.113883.10.20.22.1.3/H&P encompassingEncounter Example.xml
+++ b/Guide Examples/History and Physical (V3)_2.16.840.1.113883.10.20.22.1.3/H&P encompassingEncounter Example.xml
@@ -1,0 +1,16 @@
+<componentOf>
+  <encompassingEncounter>
+    <id extension="9937012" root="2.16.840.1.113883.19" />
+    <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" 
+               code="99213" displayName="Evaluation and Management" />
+    <effectiveTime>
+      <low value="20090227130000+0500" />
+      <high value="20090227130000+0500" />
+    </effectiveTime>
+    <location>
+      <healthCareFacility>
+        <id root="2.16.540.1.113883.19.2" />
+      </healthCareFacility>
+    </location>
+  </encompassingEncounter>
+</componentOf>

--- a/Guide Examples/History and Physical (V3)_2.16.840.1.113883.10.20.22.1.3/README.md
+++ b/Guide Examples/History and Physical (V3)_2.16.840.1.113883.10.20.22.1.3/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+History and Physical (V3)
+ 
+2.16.840.1.113883.10.20.22.1.3

--- a/Guide Examples/History of Present Illness Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/History of Present Illness Section Example.xml
+++ b/Guide Examples/History of Present Illness Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/History of Present Illness Section Example.xml
@@ -1,0 +1,23 @@
+<section>
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4.2"/>
+  <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" 
+        code="10164-2" 
+        displayName="HISTORY OF PRESENT ILLNESS"/>
+  <title>HISTORY OF PRESENT ILLNESS</title>
+  <text>
+    <paragraph>This patient was only recently discharged for a recurrent 
+        GI bleed as described below.</paragraph>
+    <paragraph>He presented to the ER today c/o a dark stool yesterday 
+        but a normal brown stool today. On exam he was hypotensive in the 
+        80s resolved after .... .... .... </paragraph>
+    <paragraph>Lab at discharge: Glucose 112, BUN 16, creatinine 1.1, 
+        electrolytes normal. H. pylori antibody pending. Admission 
+        hematocrit 16%, discharge hematocrit 29%. WBC 7300, platelet 
+        count 256,000. Urinalysis normal. Urine culture: No growth. INR 
+        1.1, PTT 40.</paragraph>
+    <paragraph>He was transfused with 6 units of packed red blood cells 
+        with .... .... ....</paragraph>
+    <paragraph>GI evaluation 12 September: Colonoscopy showed single red 
+       clot in .... .... ....</paragraph>
+  </text>
+</section>

--- a/Guide Examples/History of Present Illness Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/README.md
+++ b/Guide Examples/History of Present Illness Section_1.3.6.1.4.1.19376.1.5.3.1.3.4/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+History of Present Illness Section
+ 
+1.3.6.1.4.1.19376.1.5.3.1.3.4

--- a/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/Hospital Admission Diagnosis (V3) Example.xml
+++ b/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/Hospital Admission Diagnosis (V3) Example.xml
@@ -1,0 +1,20 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.34" extension="2015-08-01" />
+  <id root="5a784260-6856-4f38-9638-80c751aff2fb" />
+  <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Hospital Admission Diagnosis" />
+  <statusCode code="active" />
+  <effectiveTime>
+    <low value="20090303" />
+  </effectiveTime>
+  <entryRelationship typeCode="SUBJ" inversionInd="false">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Problem observation template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension=�2015-08-01� />
+                ...
+            
+        
+        
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/README.md
+++ b/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Admission Diagnosis (V3)
+ 
+2.16.840.1.113883.10.20.22.4.34

--- a/Guide Examples/Hospital Consultations Section_2.16.840.1.113883.10.20.22.2.42/Hospital Consultations Section Example.xml
+++ b/Guide Examples/Hospital Consultations Section_2.16.840.1.113883.10.20.22.2.42/Hospital Consultations Section Example.xml
@@ -1,0 +1,14 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.42"/>
+  <code code="18841-7" codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Hospital Consultations Section"/>
+  <title>HOSPITAL CONSULTATIONS</title>
+  <text>
+    <list listType="ordered">
+      <item>Gastroenterology</item>
+      <item>Cardiology</item>
+      <item>Dietitian</item>
+    </list>
+  </text>
+</section>

--- a/Guide Examples/Hospital Consultations Section_2.16.840.1.113883.10.20.22.2.42/README.md
+++ b/Guide Examples/Hospital Consultations Section_2.16.840.1.113883.10.20.22.2.42/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Consultations Section
+ 
+2.16.840.1.113883.10.20.22.2.42

--- a/Guide Examples/Hospital Course Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/Hospital Course Section Example.xml
+++ b/Guide Examples/Hospital Course Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/Hospital Course Section Example.xml
@@ -1,0 +1,10 @@
+<section>
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.5"/>
+  <code code="8648-8" 
+          displayName="HOSPITAL COURSE"
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC"/>
+  <title>Hospital Course</title>
+  <text> The patient was admitted and started on Lovenox and 
+           nitroglycerin paste.  The patient had ... </text>
+</section>

--- a/Guide Examples/Hospital Course Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/README.md
+++ b/Guide Examples/Hospital Course Section_1.3.6.1.4.1.19376.1.5.3.1.3.5/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Course Section
+ 
+1.3.6.1.4.1.19376.1.5.3.1.3.5

--- a/Guide Examples/Hospital Discharge Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.33/Hospital Discharge Diagnosis (V3) Example.xml
+++ b/Guide Examples/Hospital Discharge Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.33/Hospital Discharge Diagnosis (V3) Example.xml
@@ -1,0 +1,22 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.33" extension="2015-08-01"/>
+  <id root="5a784260-6856-4f38-9638-80c751aff2fb" />
+  <code code="11535-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HOSPITAL DISCHARGE DIAGNOSIS" />
+  <statusCode code="active" />
+  <effectiveTime>
+    <low value="201209091904-0400" />
+  </effectiveTime>
+  <entryRelationship typeCode="SUBJ" inversionInd="false">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Problem observation template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                
+            ...
+            
+        
+        
+        
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Hospital Discharge Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.33/README.md
+++ b/Guide Examples/Hospital Discharge Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.33/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Discharge Diagnosis (V3)
+ 
+2.16.840.1.113883.10.20.22.4.33

--- a/Guide Examples/Hospital Discharge Instructions Section_2.16.840.1.113883.10.20.22.2.41/Hospital Discharge Instructions Section Example.xml
+++ b/Guide Examples/Hospital Discharge Instructions Section_2.16.840.1.113883.10.20.22.2.41/Hospital Discharge Instructions Section Example.xml
@@ -1,0 +1,42 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.41"/>
+  <code code="8653-8" codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="HOSPITAL DISCHARGE INSTRUCTIONS"/>
+  <title>HOSPITAL DISCHARGE INSTRUCTIONS</title>
+  <text>
+    <list listType="ordered">
+      <item>Take all of your prescription medication as directed.</item>
+      <item>Make an appointment with your doctor to be seen two weeks from the 
+            date of your procedure.</item>
+      <item>You may feel slightly bloated after the procedure because of air 
+            that was introduced during the examination.</item>
+      <item>Call your physician if you notice:
+                
+        <br/>
+            Bleeding or black stools.
+                
+        <br/>
+            Abdominal pain.
+                
+        <br/>
+            Fever or chills.
+                
+        <br/>
+            Nausea or vomiting.
+                
+        <br/>
+            Any unusual pain or problem.
+                
+        <br/>
+            Pain or redness at the site where the intravenous needle was 
+            placed.
+                
+        <br/>
+      </item>
+      <item>Do not drink alcohol for 24 hours. Alcohol amplifies the effect of 
+            the sedatives given.</item>
+      <item>Do not drive or operate machinery for 24 hours.</item>
+    </list>
+  </text>
+</section>

--- a/Guide Examples/Hospital Discharge Instructions Section_2.16.840.1.113883.10.20.22.2.41/README.md
+++ b/Guide Examples/Hospital Discharge Instructions Section_2.16.840.1.113883.10.20.22.2.41/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Discharge Instructions Section
+ 
+2.16.840.1.113883.10.20.22.2.41

--- a/Guide Examples/Hospital Discharge Physical Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/Hospital Discharge Physical Section Example.xml
+++ b/Guide Examples/Hospital Discharge Physical Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/Hospital Discharge Physical Section Example.xml
@@ -1,0 +1,24 @@
+<section>
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.26"/>
+  <code code="10184-0" 
+             displayName="HOSPITAL DISCHARGE PHYSICAL"
+             codeSystem="2.16.840.1.113883.6.1" 
+             codeSystemName="LOINC"/>
+  <title>Hospital Discharge Physical</title>
+  <text>GENERAL: Well-developed, slightly obese man. 
+        
+    <br/>
+             NECK: Supple, with no jugular venous distension. 
+        
+    <br/>
+             HEART: Intermittent tachycardia without murmurs or gallops.
+        
+    <br/>
+             PULMONARY: Decreased breath sounds, but no clear-cut rales or
+             wheezes. 
+        
+    <br/>
+             EXTREMITIES: Free of edema.
+    
+  </text>
+</section>

--- a/Guide Examples/Hospital Discharge Physical Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/README.md
+++ b/Guide Examples/Hospital Discharge Physical Section_1.3.6.1.4.1.19376.1.5.3.1.3.26/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Discharge Physical Section
+ 
+1.3.6.1.4.1.19376.1.5.3.1.3.26

--- a/Guide Examples/Hospital Discharge Studies Summary Section_2.16.840.1.113883.10.20.22.2.16/Hospital Discharge Studies Summary Section Example.xml
+++ b/Guide Examples/Hospital Discharge Studies Summary Section_2.16.840.1.113883.10.20.22.2.16/Hospital Discharge Studies Summary Section Example.xml
@@ -1,0 +1,11 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.16"/>
+  <code code="11493-4"
+            codeSystem="2.16.840.1.113883.6.1" 
+            codeSystemName="LOINC"
+            displayName="HOSPITAL DISCHARGE STUDIES SUMMARY"/>
+  <title>Hospital Discharge Studies Summary</title>
+  <text>
+           ...
+      </text>
+</section>

--- a/Guide Examples/Hospital Discharge Studies Summary Section_2.16.840.1.113883.10.20.22.2.16/README.md
+++ b/Guide Examples/Hospital Discharge Studies Summary Section_2.16.840.1.113883.10.20.22.2.16/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Hospital Discharge Studies Summary Section
+ 
+2.16.840.1.113883.10.20.22.2.16

--- a/Guide Examples/Immunization Activity (V3)_2.16.840.1.113883.10.20.22.4.52/Immunization Activity (V3) Example.xml
+++ b/Guide Examples/Immunization Activity (V3)_2.16.840.1.113883.10.20.22.4.52/Immunization Activity (V3) Example.xml
@@ -1,0 +1,55 @@
+<substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+  <!-- ** Immunization activity ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.52" extension="2015-08-01" />
+  <id root="e6f1ba43-c0ed-4b9b-9f12-f435d8ad8f92" />
+  <statusCode code="completed" />
+  <effectiveTime value="19981215" />
+  <routeCode code="C28161" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="National Cancer Institute (NCI) Thesaurus" displayName="Intramuscular injection" />
+  <doseQuantity value="50" unit="ug" />
+  <consumable>
+    <manufacturedProduct classCode="MANU">
+      <!-- ** Immunization medication information ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
+      <manufacturedMaterial>
+        <code code="33" codeSystem="2.16.840.1.113883.6.59" displayName="Pneumococcal polysaccharide vaccine" codeSystemName="CVX">
+          <translation code="854981" displayName="Pneumovax 23 (Pneumococcal vaccine polyvalent) Injectable Solution" codeSystemName="RxNORM" codeSystem="2.16.840.1.113883.6.88" />
+        </code>
+        <lotNumberText>1</lotNumberText>
+      </manufacturedMaterial>
+      <manufacturerOrganization>
+        <name>Health LS - Immuno Inc.</name>
+      </manufacturerOrganization>
+    </manufacturedProduct>
+  </consumable>
+  <performer>
+    <assignedEntity>
+      <id root="2.16.840.1.113883.19.5.9999.456" extension="2981824" />
+      <addr>
+        <streetAddressLine>1007 Health Drive</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel: +(555)-555-1030" />
+      <assignedPerson>
+        <name>
+          <given>Harold</given>
+          <family>Hippocrates</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5.9999.1394" />
+        <name>Good Health Clinic</name>
+        <telecom use="WP" value="tel: +(555)-555-1030" />
+        <addr>
+          <streetAddressLine>1007 Health Drive</streetAddressLine>
+          <city>Portland</city>
+          <state>OR</state>
+          <postalCode>99123</postalCode>
+          <country>US</country>
+        </addr>
+      </representedOrganization>
+    </assignedEntity>
+  </performer>
+</substanceAdministration>

--- a/Guide Examples/Immunization Activity (V3)_2.16.840.1.113883.10.20.22.4.52/README.md
+++ b/Guide Examples/Immunization Activity (V3)_2.16.840.1.113883.10.20.22.4.52/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Immunization Activity (V3)
+ 
+2.16.840.1.113883.10.20.22.4.52

--- a/Guide Examples/Immunization Medication Information (V2)_2.16.840.1.113883.10.20.22.4.54/Immunization Medication Information (V2) Example.xml
+++ b/Guide Examples/Immunization Medication Information (V2)_2.16.840.1.113883.10.20.22.4.54/Immunization Medication Information (V2) Example.xml
@@ -1,0 +1,13 @@
+<manufacturedProduct classCode="MANU">
+  <!-- ** Immunization medication information ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.54" extension="2014-06-09" />
+  <manufacturedMaterial>
+    <code code="33" codeSystem="2.16.840.1.113883.12.292" displayName="Pneumococcal polysaccharide vaccine" codeSystemName="CVX">
+      <translation code="854981" displayName="Pneumovax 23 (Pneumococcal vaccine polyvalent) Injectable Solution" codeSystemName="RxNORM" codeSystem="2.16.840.1.113883.6.88" />
+    </code>
+    <lotNumberText>1</lotNumberText>
+  </manufacturedMaterial>
+  <manufacturerOrganization>
+    <name>Health LS - Immuno Inc.</name>
+  </manufacturerOrganization>
+</manufacturedProduct>

--- a/Guide Examples/Immunization Medication Information (V2)_2.16.840.1.113883.10.20.22.4.54/README.md
+++ b/Guide Examples/Immunization Medication Information (V2)_2.16.840.1.113883.10.20.22.4.54/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Immunization Medication Information (V2)
+ 
+2.16.840.1.113883.10.20.22.4.54

--- a/Guide Examples/Immunization Refusal Reason_2.16.840.1.113883.10.20.22.4.53/Immunization Refusal Reason Example.xml
+++ b/Guide Examples/Immunization Refusal Reason_2.16.840.1.113883.10.20.22.4.53/Immunization Refusal Reason Example.xml
@@ -1,0 +1,7 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.53"/>
+  <id root="2a620155-9d11-439e-92b3-5d9815ff4dd8"/>
+  <code displayName="Patient Objection" code="PATOBJ"
+		codeSystemName="HL7 ActNoImmunizationReason" codeSystem="2.16.840.1.113883.5.8"/>
+  <statusCode code="completed"/>
+</observation>

--- a/Guide Examples/Immunization Refusal Reason_2.16.840.1.113883.10.20.22.4.53/README.md
+++ b/Guide Examples/Immunization Refusal Reason_2.16.840.1.113883.10.20.22.4.53/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Immunization Refusal Reason
+ 
+2.16.840.1.113883.10.20.22.4.53

--- a/Guide Examples/Immunizations Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.2.1/Immunizations Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Immunizations Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.2.1/Immunizations Section (entries required) (V3) Example.xml
@@ -1,0 +1,69 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.1" extension="2015-08-01" />
+  <!--  ********  Immunizations section template   ******** -->
+  <code code="11369-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="History of immunizations" />
+  <title>Immunizations</title>
+  <text>
+    <table border="1" width="100%">
+      <thead>
+        <tr>
+          <th>Vaccine</th>
+          <th>Date</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <content ID="immun1" />Influenza virus vaccine, IM
+                    
+                    
+          </td>
+          <td>Nov 1999</td>
+          <td>Completed</td>
+        </tr>
+        <tr>
+          <td>
+            <content ID="immun2" />Influenza virus vaccine, IM
+                    
+                    
+          </td>
+          <td>Dec 1998</td>
+          <td>Completed</td>
+        </tr>
+        <tr>
+          <td>
+            <content ID="immun3" />
+            Pneumococcal polysaccharide vaccine, IM
+                    
+                    
+          </td>
+          <td>Dec 1998</td>
+          <td>Completed</td>
+        </tr>
+        <tr>
+          <td>
+            <content ID="immun4" />Tetanus and diphtheria toxoids, IM
+                    
+                    
+          </td>
+          <td>1997</td>
+          <td>Refused</td>
+        </tr>
+      </tbody>
+    </table>
+  </text>
+  <entry typeCode="DRIV">
+    <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="false">
+      <templateId root="2.16.840.1.113883.10.20.22.4.52" />
+      <!--  ****  Immunization activity template  **** -->
+      ...
+    
+        
+        
+    </substanceAdministration>
+  </entry>
+  ...
+
+
+</section>

--- a/Guide Examples/Immunizations Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.2.1/README.md
+++ b/Guide Examples/Immunizations Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.2.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Immunizations Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.2.1

--- a/Guide Examples/Implantable Device Status Observation_2.16.840.1.113883.10.20.22.4.305/Implantable Device Status Example.xml
+++ b/Guide Examples/Implantable Device Status Observation_2.16.840.1.113883.10.20.22.4.305/Implantable Device Status Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.305" extension="2019-06-21"/>
+	<code code="C160939" displayName="Implantable Device Status"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="CD" code="C160942" codeSystem="2.16.840.1.113883.3.26.1.1"
+ displayName="Reduced Function" codeSystemName="NCI Thesaurus"
+ sdtc:valueSet="2.16.840.1.113762.1.4.1021.48">
+		<originalText>
+			<reference value="#ImplantableDeviceStatus_1"/>
+		</originalText>
+	</value>
+</observation>

--- a/Guide Examples/Implantable Device Status Observation_2.16.840.1.113883.10.20.22.4.305/README.md
+++ b/Guide Examples/Implantable Device Status Observation_2.16.840.1.113883.10.20.22.4.305/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Implantable Device Status Observation
+ 
+2.16.840.1.113883.10.20.22.4.305

--- a/Guide Examples/Indication (V2)_2.16.840.1.113883.10.20.22.4.19/Indication (V2) Example.xml
+++ b/Guide Examples/Indication (V2)_2.16.840.1.113883.10.20.22.4.19/Indication (V2) Example.xml
@@ -1,0 +1,33 @@
+<entry typeCode="DRIV">
+  <substanceAdministration classCode="SBADM" moodCode="EVN">
+    <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+    <!-- ** MEDICATION ACTIVITY -->
+    <id root="cdbd33f0-6cde-11db-9fe1-0800200c9a66" />
+    <text>
+      <reference value="#Med1" /> 0.09 MG/ACTUAT inhalant solution, 2 puffs QID PRN wheezing 
+        
+        
+    </text>
+    ...
+
+        
+    <!-- Indication snippet inside a Medication Activity -->
+    <entryRelationship typeCode="RSON">
+      <observation classCode="OBS" moodCode="EVN">
+        <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+        <!-- Note that this id equals the problem observation/id -->
+        <id root="db734647-fc99-424c-a864-7e3cda82e703" />
+        <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+        <statusCode code="completed" />
+        <value xsi:type="CD" code="32398004" displayName="Bronchitis" codeSystem="2.16.840.1.113883.6.96" />
+      </observation>
+    </entryRelationship>
+    ...
+    
+  </substanceAdministration>
+</entry>
+<!-- Points to a problem on the problem list -->
+<!-- Problem observation template 
+        <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+        Note that this id equals the Indication observation/id
+       <id root="db734647-fc99-424c-a864-7e3cda82e703"/> -->

--- a/Guide Examples/Indication (V2)_2.16.840.1.113883.10.20.22.4.19/README.md
+++ b/Guide Examples/Indication (V2)_2.16.840.1.113883.10.20.22.4.19/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Indication (V2)
+ 
+2.16.840.1.113883.10.20.22.4.19

--- a/Guide Examples/Instruction (V2)_2.16.840.1.113883.10.20.22.4.20/Instruction (V2) Example.xml
+++ b/Guide Examples/Instruction (V2)_2.16.840.1.113883.10.20.22.4.20/Instruction (V2) Example.xml
@@ -1,0 +1,10 @@
+<act classCode="ACT" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
+  <code code="171044003" codeSystem="2.16.840.1.113883.6.96" displayName="immunization education" />
+  <text>
+    <reference value="#immunSect" />
+		Possible flu-like symptoms for three days.
+	
+  </text>
+  <statusCode code="completed" />
+</act>

--- a/Guide Examples/Instruction (V2)_2.16.840.1.113883.10.20.22.4.20/README.md
+++ b/Guide Examples/Instruction (V2)_2.16.840.1.113883.10.20.22.4.20/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Instruction (V2)
+ 
+2.16.840.1.113883.10.20.22.4.20

--- a/Guide Examples/Instructions Section (V2)_2.16.840.1.113883.10.20.22.2.45/Instructions Section (V2) Example.xml
+++ b/Guide Examples/Instructions Section (V2)_2.16.840.1.113883.10.20.22.2.45/Instructions Section (V2) Example.xml
@@ -1,0 +1,19 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.21.2.45"
+         extension="2014-06-09" />
+  <code code="69730-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="INSTRUCTIONS" />
+  <title>INSTRUCTIONS</title>
+  <text>
+    Patient may have low grade fever, mild joint pain and injection area   
+    tenderness
+  </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.20" />
+      <!-- *** Instructions template ***  -->
+       ...
+    
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Instructions Section (V2)_2.16.840.1.113883.10.20.22.2.45/README.md
+++ b/Guide Examples/Instructions Section (V2)_2.16.840.1.113883.10.20.22.2.45/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Instructions Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.45

--- a/Guide Examples/Intervention Act (V2)_2.16.840.1.113883.10.20.22.4.131/Intervention Act (moodCodeINT) Example.xml
+++ b/Guide Examples/Intervention Act (V2)_2.16.840.1.113883.10.20.22.4.131/Intervention Act (moodCodeINT) Example.xml
@@ -1,0 +1,51 @@
+<!-- 
+  This entry shows an act in intent mood (planned intervention- 
+  meaning this is intended to be done), with the reason "RSN" for the act 
+  being the already defined Goal (pulse ox reading > 92) 
+  The intervention contains relationships to different components of
+  the intervention.
+-->
+<!-- Intervention Act -->
+<act classCode="ACT" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.131" />
+  <id root="85fa4b62-e3a9-4385-b064-fe04cca35adb" />
+  <code code="code_for_intervention" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Intervention" />
+  <statusCode code="active" />
+  <entryRelationship typeCode="REFR">
+    <!-- The following act is one part of the intervention - 
+               "Elevate head of bed" -->
+    <!-- Procedure Activity Act -->
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.12" extension="2015-08-01" />
+      <id root="7658963e-54da-496f-bf18-dea1dddaa3b0" />
+      <code code="423171007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Elevate head of bed" />
+      <statusCode code="active" />
+    </act>
+  </entryRelationship>
+  <entryRelationship typeCode="REFR">
+    <!-- The following procedure is one part of the intervention - 
+      "Oxygen administration by nasal cannula" -->
+    <!-- Procedure Activity Procedure -->
+    <procedure classCode="PROC" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09" />
+      <id root="6a560f3d-88fd-4292-9415-f9371adaec46" />
+      <code code="371907003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Oxygen administration by nasal cannula" />
+      <statusCode code="active" />
+    </procedure>
+  </entryRelationship>
+  <!-- This entryRelationship represents the relationship between an 
+    Intervention Act and a Goal Observation (Intervention HAS REASON Goal). 
+    The Entry Reference template is being used here as this Goal is 
+    defined elsewhere in the CDA document -->
+  <entryRelationship typeCode="RSON">
+    <!-- Entry Reference template -->
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+      <!-- This id points to an already defined Goal 
+        (pulse ox reading > 92) in the Goals Section -->
+      <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+      <code nullFlavor="NP" />
+      <statusCode code="completed" />
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Intervention Act (V2)_2.16.840.1.113883.10.20.22.4.131/README.md
+++ b/Guide Examples/Intervention Act (V2)_2.16.840.1.113883.10.20.22.4.131/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Intervention Act (V2)
+ 
+2.16.840.1.113883.10.20.22.4.131

--- a/Guide Examples/Interventions Section (V3)_2.16.840.1.113883.10.20.21.2.3/Interventions Section (V3) Example.xml
+++ b/Guide Examples/Interventions Section (V3)_2.16.840.1.113883.10.20.21.2.3/Interventions Section (V3) Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.21.2.3" extension="2015-08-01" />
+  <code code="62387-6" displayName="Interventions Provided" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <title>Interventions Section</title>
+  <text />
+  <entry>
+    <act />
+  </entry>
+</section>

--- a/Guide Examples/Interventions Section (V3)_2.16.840.1.113883.10.20.21.2.3/README.md
+++ b/Guide Examples/Interventions Section (V3)_2.16.840.1.113883.10.20.21.2.3/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Interventions Section (V3)
+ 
+2.16.840.1.113883.10.20.21.2.3

--- a/Guide Examples/Latex Safety Status Example_2.16.840.1.113883.10.20.22.4.314/Latex Safety Status Example.xml
+++ b/Guide Examples/Latex Safety Status Example_2.16.840.1.113883.10.20.22.4.314/Latex Safety Status Example.xml
@@ -1,0 +1,16 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.314"
+ extension="2019-06-21"/>
+	<code code="C160938" displayName="Latex Safety Status"
+ codeSystem="2.16.840.1.113883.3.26.1.1"
+ codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="CD" code="C106038"
+ codeSystem="2.16.840.1.113883.3.26.1.1" displayName="Not Made with Natural
+Rubber Latex"
+ codeSystemName="NCI Thesaurus"
+sdtc:valueSet="2.16.840.1.113762.1.4.1021.47">
+		<originalText>
+			<reference value="#LatexSafety_1"/>
+		</originalText>
+	</value>
+</observation>

--- a/Guide Examples/Latex Safety Status Example_2.16.840.1.113883.10.20.22.4.314/README.md
+++ b/Guide Examples/Latex Safety Status Example_2.16.840.1.113883.10.20.22.4.314/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Latex Safety Status Example
+ 
+2.16.840.1.113883.10.20.22.4.314

--- a/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal Care Wound Observation Example.xml
+++ b/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal Care Wound Observation Example.xml
@@ -1,0 +1,67 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Wound Observation template -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.114" extension=�2015-08-01� />
+    <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+    <statusCode code="completed" />
+    <effectiveTime>
+      <low value="20013103" />
+    </effectiveTime>
+    <value xsi:type="CD" code="425144005" codeSystem="2.16.840.1.113883.6.6" displayName="Minor open wound" />
+    <targetSiteCode code="182295001" codeSystem="2.16.840.1.113883.6.96" displayName="anterior aspect of knee" />
+    <author>
+          ...
+        </author>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Wound Measurements Observation -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.133" />
+               ...
+        
+            
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Wound Measurements Observation . -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.133" />
+               ...
+        
+                
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Wound Characteristic -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.134" />
+              ...
+        
+                    
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Number of Pressure Ulcers -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.76" />
+       ...
+      
+                        
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Highest Pressure  Ulcers Stage -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.77" />
+              ...
+         
+                            
+            
+      </observation>
+    </entryRelationship>
+  </observation>
+</entry>

--- a/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/README.md
+++ b/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Longitudinal Care Wound Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.114

--- a/Guide Examples/Lot or Batch Number Observation_2.16.840.1.113883.10.20.22.4.315/Lot or Batch Number Example.xml
+++ b/Guide Examples/Lot or Batch Number Observation_2.16.840.1.113883.10.20.22.4.315/Lot or Batch Number Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.315" extension="2019-06-21"/>
+	<code code="C101672" displayName="Lot or Batch Number"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#LotOrBatchNumber_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Lot or Batch Number Observation_2.16.840.1.113883.10.20.22.4.315/README.md
+++ b/Guide Examples/Lot or Batch Number Observation_2.16.840.1.113883.10.20.22.4.315/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Lot or Batch Number Observation
+ 
+2.16.840.1.113883.10.20.22.4.315

--- a/Guide Examples/MRI Safety Status Observation_2.16.840.1.113883.10.20.22.4.318/MRI Safety Status Example.xml
+++ b/Guide Examples/MRI Safety Status Observation_2.16.840.1.113883.10.20.22.4.318/MRI Safety Status Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.318" extension="2019-06-21"/>
+	<code code="C106044" displayName="MRI Safety Status"
+ codeSystem="2.16.840.1.113883.3.26.1.1"codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="CD" code="C113844" codeSystem="2.16.840.1.113883.3.26.1.1"
+ displayName="Labeling does not contain MRI Safety Information"
+ codeSystemName="NCI Thesaurus" sdtc:valueSet="2.16.840.1.113762.1.4.1021.46">
+		<originalText>
+			<reference value="#MRISafety_1"/>
+		</originalText>
+	</value>
+</observation>

--- a/Guide Examples/MRI Safety Status Observation_2.16.840.1.113883.10.20.22.4.318/README.md
+++ b/Guide Examples/MRI Safety Status Observation_2.16.840.1.113883.10.20.22.4.318/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+MRI Safety Status Observation
+ 
+2.16.840.1.113883.10.20.22.4.318

--- a/Guide Examples/Manufacturing Date Observation_2.16.840.1.113883.10.20.22.4.316/Manufacturing Date Example.xml
+++ b/Guide Examples/Manufacturing Date Observation_2.16.840.1.113883.10.20.22.4.316/Manufacturing Date Example.xml
@@ -1,0 +1,6 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.316" extension="2019-06-21"/>
+	<code code="C101669" displayName="Manufacturing Date"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="TS" value="20181015"/>
+</observation>

--- a/Guide Examples/Manufacturing Date Observation_2.16.840.1.113883.10.20.22.4.316/README.md
+++ b/Guide Examples/Manufacturing Date Observation_2.16.840.1.113883.10.20.22.4.316/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Manufacturing Date Observation
+ 
+2.16.840.1.113883.10.20.22.4.316

--- a/Guide Examples/Medical Equipment Organizer_2.16.840.1.113883.10.20.22.4.135/Medical Equipment Organizer Example.xml
+++ b/Guide Examples/Medical Equipment Organizer_2.16.840.1.113883.10.20.22.4.135/Medical Equipment Organizer Example.xml
@@ -1,0 +1,29 @@
+<organizer classCode="CLUSTER" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.135" />
+  <!-- Medical Equipment Organizer template -->
+  <id root="3e414708-0e61-4d48-8863-484a2d473a02" />
+  <code code="337588003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Incontinence appliances">
+    <originalText>Incontinence appliances</originalText>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime xsi:type="IVL_TS">
+    <low value="20070103" />
+    <high nullFlavor="UNK" />
+  </effectiveTime>
+  <component>
+    <supply classCode="SPLY" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.50" extension="2014-06-09" />
+      <!-- Non-medicinal supply activity V2 template ******* -->
+            ...
+        
+    </supply>
+  </component>
+  <component>
+    <supply classCode="SPLY" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.50" extension="2014-06-09" />
+      <!-- Non-medicinal supply activity V2 template ******* -->
+           ...
+        
+    </supply>
+  </component>
+</organizer>

--- a/Guide Examples/Medical Equipment Organizer_2.16.840.1.113883.10.20.22.4.135/README.md
+++ b/Guide Examples/Medical Equipment Organizer_2.16.840.1.113883.10.20.22.4.135/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medical Equipment Organizer
+ 
+2.16.840.1.113883.10.20.22.4.135

--- a/Guide Examples/Medical Equipment Section (V2)_2.16.840.1.113883.10.20.22.2.23/Medical Equipment Section (V2) Example.xml
+++ b/Guide Examples/Medical Equipment Section (V2)_2.16.840.1.113883.10.20.22.2.23/Medical Equipment Section (V2) Example.xml
@@ -1,0 +1,41 @@
+<component>
+  <section>
+    <!-- Medical equipment section -->
+    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09" />
+    <code code="46264-8" codeSystem="2.16.840.1.113883.6.1" />
+    <title>MEDICAL EQUIPMENT</title>
+    <text>
+      <content styleCode="Bold">Medical Equipment</content>
+      <list>
+        <item>Implanted Devices: Cardiac Pacemaker July 3, 2013</item>
+        <item>Implanted Devices: Upper GI Prosthesis, January 3, 2013</item>
+        <item>Cane, February 2, 2003</item>
+        <item>Biliary Stent, May 5, 2013</item>
+      </list>
+    </text>
+    <entry>
+      <organizer classCode="CLUSTER" moodCode="EVN">
+        <!-- Medical Equipment Organizer template -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.135" />
+                ...
+            
+      </organizer>
+    </entry>
+    <entry>
+      <supply classCode="SPLY" moodCode="EVN">
+        <!-- Non-medicinal supply activity V2 template ******* -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.50" extension="2014-06-09" />
+                ...
+            
+      </supply>
+    </entry>
+    <entry>
+      <procedure classCode="PROC" moodCode="EVN">
+        <!-- Procedure Activity Procedure V2-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09" />
+                ...
+            
+      </procedure>
+    </entry>
+  </section>
+</component>

--- a/Guide Examples/Medical Equipment Section (V2)_2.16.840.1.113883.10.20.22.2.23/README.md
+++ b/Guide Examples/Medical Equipment Section (V2)_2.16.840.1.113883.10.20.22.2.23/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medical Equipment Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.23

--- a/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/Medication Activity (V2) Example.xml
+++ b/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/Medication Activity (V2) Example.xml
@@ -1,0 +1,48 @@
+<substanceAdministration classCode="SBADM" moodCode="EVN">
+  <!-- ** Medication Activity (V2) ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.16" 
+         extension="2014-06-09"/>
+  <id root="6c844c75-aa34-411c-b7bd-5e4a9f206e29"/>
+  <statusCode code="active"/>
+  <effectiveTime xsi:type="IVL_TS">
+    <low value="20120318"/>
+  </effectiveTime>
+  <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+    <period value="12" unit="h"/>
+  </effectiveTime>
+  <routeCode code="C38288" 
+            codeSystem="2.16.840.1.113883.3.26.1.1" 
+            codeSystemName="NCI Thesaurus" 
+            displayName="ORAL"/>
+  <doseQuantity value="1"/>
+  <consumable>
+    <manufacturedProduct classCode="MANU">
+      <!-- ** Medication information ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" 
+               extension="2014-06-09"/>
+      <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8"/>
+      <manufacturedMaterial>
+        <code code="197380"  
+              displayName="Atenolol 25 MG Oral Tablet" 
+              codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm"/>
+      </manufacturedMaterial>
+    </manufacturedProduct>
+  </consumable>
+  <entryRelationship typeCode="RSON">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Indication ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.19" 
+             extension="2014-06-09"/>
+      <id root="e63166c7-6482-4a44-83a1-37ccdbde725b"/>
+      <code code="75321-0" 
+            codeSystem="2.16.840.1.113883.6.1" 
+            codeSystemName="LOINC" 
+            displayName="Clinical finding"/>
+      <statusCode code="completed"/>
+      <value xsi:type="CD" 
+             code="38341003" 
+             displayName="Hypertension" 
+             codeSystem="2.16.840.1.113883.6.96"/>
+    </observation>
+  </entryRelationship>
+</substanceAdministration>

--- a/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/No Known Medications Example.xml
+++ b/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/No Known Medications Example.xml
@@ -1,0 +1,20 @@
+<substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+  <!-- ** Medication activity ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+  <id root="072f00fc-4f9d-4516-8d6f-ed00ed523fe0" />
+  <statusCode code="active" />
+  <effectiveTime xsi:type="IVL_TS">
+    <low value="20110103" />
+  </effectiveTime>
+  <consumable>
+    <manufacturedProduct classCode="MANU">
+      <!-- ** Medication information ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+      <manufacturedMaterial>
+        <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.88">
+          <translation code="410942007" displayName="drug or medication" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+        </code>
+      </manufacturedMaterial>
+    </manufacturedProduct>
+  </consumable>
+</substanceAdministration>

--- a/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/README.md
+++ b/Guide Examples/Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.16/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medication Activity (V2)
+ 
+2.16.840.1.113883.10.20.22.4.16

--- a/Guide Examples/Medication Dispense (V2)_2.16.840.1.113883.10.20.22.4.18/Medication Dispense (V2) Example.xml
+++ b/Guide Examples/Medication Dispense (V2)_2.16.840.1.113883.10.20.22.4.18/Medication Dispense (V2) Example.xml
@@ -1,0 +1,21 @@
+<supply classCode="SPLY" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.18" extension="2014-06-09" />
+  <id root="1.2.3.4.56789.1" extension="cb734647-fc99-424c-a864-7e3cda82e704" />
+  <statusCode code="completed" />
+  <effectiveTime value="201208151450-0800" />
+  <repeatNumber value="1" />
+  <quantity value="75" />
+  <product>
+    <manufacturedProduct classCode="MANU">
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+            . . .
+
+        
+    </manufacturedProduct>
+  </product>
+  <performer>
+    <assignedEntity>
+        . . .
+        </assignedEntity>
+  </performer>
+</supply>

--- a/Guide Examples/Medication Dispense (V2)_2.16.840.1.113883.10.20.22.4.18/README.md
+++ b/Guide Examples/Medication Dispense (V2)_2.16.840.1.113883.10.20.22.4.18/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medication Dispense (V2)
+ 
+2.16.840.1.113883.10.20.22.4.18

--- a/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/Medication Free Text Sig Example.xml
+++ b/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/Medication Free Text Sig Example.xml
@@ -1,0 +1,17 @@
+<!-- moodCode matches the parent substanceAdministration EVN or INT -->
+<substanceAdministration classCode=�SBADM� moodCode=�EVN�>
+  <templateId root=�2.16.840.1.113883.10.20.22.4.147�/>
+  <code code="76662-6" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="Medication Instructions"/>
+  <text>
+    <!-- Reference into the section.text to a tag that ONLY contains free text SIG -->
+    <reference value="#AD1"/>
+  </text>
+  <consumable>
+    <manufacturedProduct>
+      <manufacturedLabeledDrug nullFlavor=�NA�/>
+    </manufacturedProduct>
+  </consumable>
+</substanceAdministration>

--- a/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/README.md
+++ b/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medication Free Text Sig
+ 
+2.16.840.1.113883.10.20.22.4.147

--- a/Guide Examples/Medication Information (V2)_2.16.840.1.113883.10.20.22.4.23/Medication Information (V2) Example.xml
+++ b/Guide Examples/Medication Information (V2)_2.16.840.1.113883.10.20.22.4.23/Medication Information (V2) Example.xml
@@ -1,0 +1,11 @@
+<manufacturedProduct classCode="MANU">
+  <!-- ** Medication information ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+  <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
+  <manufacturedMaterial>
+    <code code="745679" displayName="200 ACTUAT Albuterol 0.09 MG/ACTUAT Metered Dose Inhaler" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+  </manufacturedMaterial>
+  <manufacturerOrganization>
+    <name>Medication Factory Inc.</name>
+  </manufacturerOrganization>
+</manufacturedProduct>

--- a/Guide Examples/Medication Information (V2)_2.16.840.1.113883.10.20.22.4.23/README.md
+++ b/Guide Examples/Medication Information (V2)_2.16.840.1.113883.10.20.22.4.23/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medication Information (V2)
+ 
+2.16.840.1.113883.10.20.22.4.23

--- a/Guide Examples/Medication Supply Order (V2)_2.16.840.1.113883.10.20.22.4.17/Medication Supply Order (V2) Example.xml
+++ b/Guide Examples/Medication Supply Order (V2)_2.16.840.1.113883.10.20.22.4.17/Medication Supply Order (V2) Example.xml
@@ -1,0 +1,34 @@
+<supply classCode="SPLY" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.17" extension="2014-06-09" />
+  <id root="aba2fc75-1a43-435f-8309-d24e4be5f1cd" />
+  <statusCode code="completed" />
+  <effectiveTime xsi:type="IVL_TS">
+    <low value="20070103" />
+    <high nullFlavor="UNK" />
+  </effectiveTime>
+  <repeatNumber value="1" />
+  <quantity value="75" />
+  <product>
+    <manufacturedProduct classCode="MANU">
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+            
+            . . .
+
+        
+    </manufacturedProduct>
+  </product>
+  <author>
+        
+    . . . 
+
+    </author>
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
+            
+            . . .
+
+        
+    </act>
+  </entryRelationship>
+</supply>

--- a/Guide Examples/Medication Supply Order (V2)_2.16.840.1.113883.10.20.22.4.17/README.md
+++ b/Guide Examples/Medication Supply Order (V2)_2.16.840.1.113883.10.20.22.4.17/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medication Supply Order (V2)
+ 
+2.16.840.1.113883.10.20.22.4.17

--- a/Guide Examples/Medications Administered Section (V2)_2.16.840.1.113883.10.20.22.2.38/Medications Administered Section (V2) Example.xml
+++ b/Guide Examples/Medications Administered Section (V2)_2.16.840.1.113883.10.20.22.2.38/Medications Administered Section (V2) Example.xml
@@ -1,0 +1,41 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09" />
+  <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="MEDICATIONS ADMINISTERED" />
+  <title>MEDICATIONS ADMINISTERED</title>
+  <text>
+    <table border="1" width="100%">
+      <thead>
+        <tr>
+          <th>Medication</th>
+          <th>Directions</th>
+          <th>Start Date</th>
+          <th>Status</th>
+          <th>Indications</th>
+          <th>Fill Instructions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <content ID="MedAdministered_1">
+                            Proventil 0.09 MG/ACTUAT inhalant solution
+                        </content>
+          </td>
+          <td>0.09 MG/ACTUAT inhalant solution, 2 puffs QID PRN wheezing</td>
+          <td>20070103</td>
+          <td>Active</td>
+          <td>Pneumonia (233604007 SNOMED CT)</td>
+          <td>Generic Substitution Allowed</td>
+        </tr>
+      </tbody>
+    </table>
+  </text>
+  <entry typeCode="DRIV">
+    <substanceAdministration classCode="SBADM" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+      <!-- ** MEDICATION ACTIVITY V2 ** -->
+                ...
+        
+    </substanceAdministration>
+  </entry>
+</section>

--- a/Guide Examples/Medications Administered Section (V2)_2.16.840.1.113883.10.20.22.2.38/README.md
+++ b/Guide Examples/Medications Administered Section (V2)_2.16.840.1.113883.10.20.22.2.38/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medications Administered Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.38

--- a/Guide Examples/Medications Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.1.1/Medications Section (entries required) (V2) Example.xml
+++ b/Guide Examples/Medications Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.1.1/Medications Section (entries required) (V2) Example.xml
@@ -1,0 +1,19 @@
+<section>
+  <!--**MEDICATION SECTION (coded entries required) ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09" />
+  <!-- Medications Section (entries optional) -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.1" extension="2014-06-09" />
+  <code code="10160-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF MEDICATION USE" />
+  <title>MEDICATIONS</title>
+  <text>
+        Narrative Text    
+    </text>
+  <entry>
+    <substanceAdministration classCode="SBADM" moodCode="EVN">
+      <!--**MEDICATION ACTIVITY V2 ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.16" extension="2014-06-09" />
+            ....
+        
+    </substanceAdministration>
+  </entry>
+</section>

--- a/Guide Examples/Medications Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.1.1/README.md
+++ b/Guide Examples/Medications Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.1.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Medications Section (entries required) (V2)
+ 
+2.16.840.1.113883.10.20.22.2.1.1

--- a/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/Mental Status Observation (V3) Example.xml
+++ b/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/Mental Status Observation (V3) Example.xml
@@ -1,0 +1,49 @@
+<entry>
+  <organizer classCode="CLUSTER" moodCode="EVN">
+    <!-- Mental Status Organizer-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.75" extension="2015-08-01" />
+    <id root="a7bc1062-8649-42a0-833d-ekd65bd013c9" />
+    <code code="75275-8" 
+                                    displayName="Cognitive function"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" />
+    <statusCode code="completed" />
+    <component>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Mental Status Observation V3 -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
+                 ...
+ 
+                
+                
+        <code code="373930000" displayName="Cognitive function" 
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+          <translation code="75275-8" 
+                                    displayName="Cognitive function"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+        </code>
+        <statusCode code="completed"/>
+                            ...
+        
+            
+        <!-- Value element holds the Cognitive Function assessment -->
+            
+                   ...
+            
+      </observation>
+    </component>
+    <component>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Mental Status Observation V3 -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
+              ...
+            
+                
+            
+            
+            
+      </observation>
+    </component>
+  </organizer>
+</entry>

--- a/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/README.md
+++ b/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Mental Status Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.74

--- a/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/Mental Status Organizer (V3) Example.xml
+++ b/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/Mental Status Organizer (V3) Example.xml
@@ -1,0 +1,49 @@
+<entry>
+  <organizer classCode="CLUSTER" moodCode="EVN">
+    <!-- Mental Status Organizer V3-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.75" extension="2015-08-01" />
+    <id root="a7bc1062-8649-42a0-833d-ekd65bd013c9" />
+    <code code="75275-8" 
+                                    displayName="Cognitive function"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC" />
+    <statusCode code="completed" />
+    <component>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Mental Status Observation V3-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
+                 ...
+ 
+                
+                
+        <code code="373930000" displayName="Cognitive function" 
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+          <translation code="75275-8" 
+                                    displayName="Cognitive function"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+        </code>
+        <statusCode code="completed"/>
+                            ...
+        
+            
+        <!-- Value element holds the Cognitive Function assessment -->
+            
+                   ...
+            
+      </observation>
+    </component>
+    <component>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Mental Status Observation V3 -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
+              ...
+            
+                
+            
+            
+            
+      </observation>
+    </component>
+  </organizer>
+</entry>

--- a/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/README.md
+++ b/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Mental Status Organizer (V3)
+ 
+2.16.840.1.113883.10.20.22.4.75

--- a/Guide Examples/Mental Status Section (V2)_2.16.840.1.113883.10.20.22.2.56/Mental Status Section Example.xml
+++ b/Guide Examples/Mental Status Section (V2)_2.16.840.1.113883.10.20.22.2.56/Mental Status Section Example.xml
@@ -1,0 +1,44 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2015-08-01" />
+  <!-- Mental Status Section -->
+  <code code="10190-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="MENTAL STATUS" />
+  <title>MENTAL STATUS</title>
+  <text>
+      ...
+    </text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Mental Status Observation template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.125" extension="2015-08-01" />
+               ...
+        
+        
+        
+        
+        
+    </observation>
+  </entry>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Mental Status Observation V2 -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.74" extension="2015-08-01" />
+            ...
+          
+        
+        
+        
+    </observation>
+  </entry>
+  <entry>
+    <organizer classCode="CLUSTER" moodCode="EVN">
+      <!-- Mental Status Organizer V2-->
+      <templateId root="2.16.840.1.113883.10.20.22.4.75" extension="2015-08-01" />
+      <id root="a7bc1062-8649-42a0-833d-ekd65bd013c9" />
+             ...
+                
+        
+        
+        
+    </organizer>
+  </entry>
+</section>

--- a/Guide Examples/Mental Status Section (V2)_2.16.840.1.113883.10.20.22.2.56/README.md
+++ b/Guide Examples/Mental Status Section (V2)_2.16.840.1.113883.10.20.22.2.56/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Mental Status Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.56

--- a/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/Model Number Example.xml
+++ b/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/Model Number Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.317" extension="2019-06-21"/>
+	<code code="C99285"displayName="Model Number"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#ModelNumber_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/README.md
+++ b/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Model Number Observation
+ 
+2.16.840.1.113883.10.20.22.4.317

--- a/Guide Examples/Non-Medicinal Supply Activity (V2)_2.16.840.1.113883.10.20.22.4.50/Non-Medicinal Supply Activity (V2) Example.xml
+++ b/Guide Examples/Non-Medicinal Supply Activity (V2)_2.16.840.1.113883.10.20.22.4.50/Non-Medicinal Supply Activity (V2) Example.xml
@@ -1,0 +1,28 @@
+
+
+<supply classCode="SPLY" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.50" extension="2014-06-09" />
+  <!-- Non-medicinal supply activity V2 template ******* -->
+  <id root="39b5f1b4-a8e1-4ad7-8849-0deab10c97b1" />
+  <statusCode code="completed" />
+  <effectiveTime xsi:type="IVL_TS">
+    <high value="20130703" />
+  </effectiveTime>
+  <quantity value="1" />
+  <participant typeCode="PRD">
+    <participantRole classCode="MANU">
+      <templateId root="2.16.840.1.113883.10.20.22.4.37" />
+      <!-- Product instance template -->
+      <id root="24993f33-6222-41ce-add6-37a9d3da6acb" />
+      <playingDevice>
+        <code code="14106009" displayName="cardiac pacemaker, device (physical object)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+          <originalText>Cardiac Pacemaker</originalText>
+        </code>
+      </playingDevice>
+      <scopingEntity>
+        <id root="eb936010-7b17-11db-9fe1-0800200c9b65" />
+        <desc>Good Health Durable Medical Equipment</desc>
+      </scopingEntity>
+    </participantRole>
+  </participant>
+</supply>

--- a/Guide Examples/Non-Medicinal Supply Activity (V2)_2.16.840.1.113883.10.20.22.4.50/README.md
+++ b/Guide Examples/Non-Medicinal Supply Activity (V2)_2.16.840.1.113883.10.20.22.4.50/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Non-Medicinal Supply Activity (V2)
+ 
+2.16.840.1.113883.10.20.22.4.50

--- a/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/Note Activity as Standalone Entry.xml
+++ b/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/Note Activity as Standalone Entry.xml
@@ -1,0 +1,49 @@
+<section>
+  <!-- C-CDA 2.1 Procedures Section, entries optional -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.7"/>
+  <templateId root="2.16.840.1.113883.10.20.22.2.7" extension="2014-06-09"/>
+  <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF PROCEDURES"/>
+  <title>Procedures</title>
+  <text>
+    <list>
+      <item ID="ProcedureNote1">
+        <paragraph>Dr. Physician - 03 Feb 2014</paragraph>
+        <paragraph>Free-text note about procedures which have occurred during this visit.</paragraph>
+      </item>
+    </list>
+  </text>
+  <!-- If section were entries required, an additional <entry nullFlavor="NI"> would be required for a Procedure Activity -->
+  <!-- Note Activity entry -->
+  <entry>
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.202" extension="2016-11-01"/>
+      <code code="34109-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=?ote?
+                
+        <translation code="28570-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Procedure note" />
+      </code>
+      <text>
+        <reference value="#ProcedureNote1" />
+      </text>
+      <statusCode code="completed"/>
+      <!-- Clinically-relevant time of the note -->
+      <effectiveTime value="20140203" />
+      <!-- Author Participation -->
+      <author>
+        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+        <!-- Time note was actually written -->
+        <time value="20140204083215-0500" />
+        <assignedAuthor>
+          <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+          <name>Dr. Physician</name>
+        </assignedAuthor>
+      </author>
+      <!-- Reference to encounter -->
+      <entryRelationship typeCode="COMP" inversionInd="true">
+        <encounter>
+          <!-- Encounter ID matches an encounter in the Encounters Section -->
+          <id root="1.2.3.4" />
+        </encounter>
+      </entryRelationship>
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/Note Activity as entryRelationship to C-CDA Entry.xml
+++ b/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/Note Activity as entryRelationship to C-CDA Entry.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section>
+  <!-- C-CDA 2.1 Procedures Section -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+  <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+  <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF PROCEDURES"/>
+  <title>Procedures</title>
+  <text>
+    <table>
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th>Date and Time (Range)</th>
+          <th>Status</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ID="Procedure1">
+          <td ID="ProcedureDesc1">Laparoscopic appendectomy</td>
+          <td>(03 Feb 2014 09:22am- 03 Feb 2014 11:15am)</td>
+          <td>Completed</td>
+          <td ID="ProcedureNote1">
+            <paragraph>Dr. Physician - 03 Feb 2014</paragraph>
+            <paragraph>Free-text note about the procedure.</paragraph>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </text>
+  <entry typeCode="DRIV">
+    <!-- Procedures should be used for care that directly changes the patient's physical state.-->
+    <procedure moodCode="EVN" classCode="PROC">
+      <templateId root="2.16.840.1.113883.10.20.22.4.14" />
+      <id root="64af26d5-88ef-4169-ba16-c6ef16a1824f"/>
+      <code code="6025007" displayName="Laparoscopic appendectomy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT">
+        <originalText>
+          <reference value="#ProcedureDesc1" />
+        </originalText>
+      </code>
+      <text>
+        <reference value="#Procedure1" />
+      </text>
+      <statusCode code="completed" />
+      <effectiveTime>
+        <low value="20140203092205-0700" />
+        <high value="20140203111514-0700" />
+      </effectiveTime>
+      <!-- Note Activity entry -->
+      <entryRelationship typeCode="COMP">
+        <act classCode="ACT" moodCode="EVN">
+          <templateId root="2.16.840.1.113883.10.20.22.4.202" extension="2016-11-01"/>
+          <code code="34109-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=?ote?
+                        
+            <translation code="28570-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Procedure note" />
+          </code>
+          <text>
+            <reference value="#ProcedureNote1" />
+          </text>
+          <statusCode code="completed"/>
+          <!-- Clinically-relevant time of the note -->
+          <effectiveTime value="20140203" />
+          <!-- Author Participation -->
+          <author>
+            <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+            <!-- Time note was actually written -->
+            <time value="20140204083215-0500" />
+            <assignedAuthor>
+              <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+              <name>Dr. Physician</name>
+            </assignedAuthor>
+          </author>
+          <!-- Reference to encounter -->
+          <entryRelationship typeCode="COMP" inversionInd="true">
+            <encounter>
+              <!-- Encounter ID matches an encounter in the Encounters Section -->
+              <id root="1.2.3.4" />
+            </encounter>
+          </entryRelationship>
+        </act>
+      </entryRelationship>
+    </procedure>
+  </entry>
+</section>

--- a/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/README.md
+++ b/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Note Activity
+ 
+2.16.840.1.113883.10.20.22.4.202

--- a/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/RTF Example.xml
+++ b/Guide Examples/Note Activity_2.16.840.1.113883.10.20.22.4.202/RTF Example.xml
@@ -1,0 +1,21 @@
+<section>
+  <!--...    -->
+  <text>
+    <list>
+      <item ID="note1">
+        <caption>Nursing Note written by Nick Nurse</caption>
+        <paragraph>Completed rounds; no incident</paragraph>
+      </item>
+    </list>
+  </text>
+  <!-- Note Activity (extra markup removed to focus on <text>) -->
+  <entry>
+    <act>
+      <code>...</code>
+      <text mediaType="text/rtf" representation="B64">e1xydGYxXGFuc2lcYW5zaWNwZzEyNTJcZGVmZjBcbm91aWNvbXBhdFxkZWZsYW5nMTAzM3tcZm9udHRibHtcZjBcZm5pbFxmY2hhcnNldDAgQ2FsaWJyaTt9fQ0Ke1wqXGdlbmVyYXRvciBSaWNoZWQyMCA2LjMuOTYwMH1cdmlld2tpbmQ0XHVjMSANClxwYXJkXHNhMjAwXHNsMjc2XHNsbXVsdDFcZjBcZnMyMlxsYW5nOSBDb21wbGV0ZWQgcm91bmRzOyBubyBpbmNpZGVudFxwYXINCn0NCiA=            
+                
+        <reference value="#note1"/>
+      </text>
+      <!--...-->
+    </act>
+  </entry>

--- a/Guide Examples/Notes Section_2.16.840.1.113883.10.20.22.2.65/Note Section Example.xml
+++ b/Guide Examples/Notes Section_2.16.840.1.113883.10.20.22.2.65/Note Section Example.xml
@@ -1,0 +1,31 @@
+<section>
+  <!-- Notes Section -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+  <code code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Consultation note"/>
+  <title>Consultation Notes</title>
+  <text>
+    <list>
+      <item ID="ConsultNote1">
+        <paragraph>Dr. Specialist - September 8, 2016</paragraph>
+        <paragraph>Evaluated patient due to symptoms of...</paragraph>
+      </item>
+    </list>
+  </text>
+  <!-- Note Activity entry -->
+  <entry>
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.202" extension="2016-11-01"/>
+      <code code="34109-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=?ote?
+                
+        <!-- Code must match or be equivalent to section code -->
+        <translation code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Consultation note" />
+      </code>
+      <text>
+        <reference value="#ConsultNote1" />
+      </text>
+      <statusCode code="completed"/>
+      <!-- Clinically-relevant time of the note -->
+      <effectiveTime value="20160908" />
+      <!--...-->
+    </entry>
+  </section>

--- a/Guide Examples/Notes Section_2.16.840.1.113883.10.20.22.2.65/README.md
+++ b/Guide Examples/Notes Section_2.16.840.1.113883.10.20.22.2.65/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Notes Section
+ 
+2.16.840.1.113883.10.20.22.2.65

--- a/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/Number of Pressure Ulcers Observation (V3) Example.xml
+++ b/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/Number of Pressure Ulcers Observation (V3) Example.xml
@@ -1,0 +1,22 @@
+<entryRelationship typeCode="COMP">
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Number of Pressure Ulcers -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.76" extension="2015-08-01"/>
+    <id root="08edb7c0-2111-43f2-a784-9a5fdfaa67f0" />
+    <code code="2264892003" displayName="Number of pressure ulcers" 
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+      <translation code="75277-4" 
+                                    displayName="Number of pressure ulcers"
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+    </code>
+    <statusCode code="completed" />
+    <value xsi:type="INT" value="3" />
+    <entryRelationship typeCode="SUBJ">
+      <observation classCode="OBS" moodCode="EVN">
+        <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+        <value xsi:type="CD" code="421927004" codeSystem="2.16.840.1.113883.6.96" displayName="Pressure ulcer stage 3" />
+      </observation>
+    </entryRelationship>
+  </observation>
+</entryRelationship>

--- a/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/README.md
+++ b/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Number of Pressure Ulcers Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.76

--- a/Guide Examples/Nutrition Assessment_2.16.840.1.113883.10.20.22.4.138/Nutrition Assessment Example.xml
+++ b/Guide Examples/Nutrition Assessment_2.16.840.1.113883.10.20.22.4.138/Nutrition Assessment Example.xml
@@ -1,0 +1,24 @@
+<entryRelationship typeCode="SUBJ">
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- ** Nutrition Assessment** -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.138" />
+    <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+    <code code="75303-8" 
+              displayName="Nutrition assessment"
+              codeSystem="2.16.840.1.113883.6.1" 
+              codeSystemName="LOINC" />
+    <statusCode code="completed" />
+    <effectiveTime value="20130512" />
+    <value xsi:type="CD" code="437421000124105" 
+              displayName="Decreased sodium diet (regime/therapy)"
+              codeSystem="2.16.840.1.113883.6.96" 
+              codeSystemName="SNOMED CT" />
+    <author typeCode="AUT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+      <time value="201300512" />
+        ...
+
+        
+    </author>
+  </observation>
+</entryRelationship>

--- a/Guide Examples/Nutrition Assessment_2.16.840.1.113883.10.20.22.4.138/README.md
+++ b/Guide Examples/Nutrition Assessment_2.16.840.1.113883.10.20.22.4.138/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Nutrition Assessment
+ 
+2.16.840.1.113883.10.20.22.4.138

--- a/Guide Examples/Nutrition Recommendation_2.16.840.1.113883.10.20.22.4.130/Nutrition Recommendation Example.xml
+++ b/Guide Examples/Nutrition Recommendation_2.16.840.1.113883.10.20.22.4.130/Nutrition Recommendation Example.xml
@@ -1,0 +1,13 @@
+<entry>
+  <act moodCode="INT" classCode="ACT">
+    <!-- Nutrition Recommendation ACT-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.130" />
+    <id root="9a6d1bac-17d3-4195-89a4-1121bc809a5c" />
+    <code code="61310001" 
+               displayName="nutrition education" 
+               codeSystem="2.16.840.1.113883.6.96" 
+               codeSystemName="SNOMED CT" />
+    <statusCode code="active" />
+    <effectiveTime value="20130512" />
+  </act>
+</entry>

--- a/Guide Examples/Nutrition Recommendation_2.16.840.1.113883.10.20.22.4.130/README.md
+++ b/Guide Examples/Nutrition Recommendation_2.16.840.1.113883.10.20.22.4.130/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Nutrition Recommendation
+ 
+2.16.840.1.113883.10.20.22.4.130

--- a/Guide Examples/Nutrition Section_2.16.840.1.113883.10.20.22.2.57/Nutrition Section Example.xml
+++ b/Guide Examples/Nutrition Section_2.16.840.1.113883.10.20.22.2.57/Nutrition Section Example.xml
@@ -1,0 +1,30 @@
+    
+<section>
+  <!--  Nutrition Section  -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.57" />
+  <code code="61144-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Diet and Nutrition" />
+  <title>NUTRITION SECTION</title>
+  <text>
+    <paragraph>Nutritional Status: well nourished</paragraph>
+    <paragraph>Nutrition Assessment: Dietary Requirements; low sodium diet, Dietary Intake, high carbohydrate diet; BMI 25-29 overweight </paragraph>
+    <paragraph>Nutritional Recommendations: BMI 22; Nutrition Education "Lean Meats"</paragraph>
+  </text>
+  <entry>
+    <!-- SHOULD HAVE Nutritional Status Observation  -->
+    <observation classCode="OBS" moodCode="EVN">
+      <!--  contains NUTRITIONAL STATUS Observation -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.124" />
+                ...
+                
+      <entryRelationship typeCode="SUBJ">
+        <observation classCode="OBS" moodCode="EVN">
+          <!-- ** Nutritional Assessment observation** -->
+          <templateId root="2.16.840.1.113883.10.20.22.4.138" />
+          <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+                       ...
+                    
+        </observation>
+      </entryRelationship>
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Nutrition Section_2.16.840.1.113883.10.20.22.2.57/README.md
+++ b/Guide Examples/Nutrition Section_2.16.840.1.113883.10.20.22.2.57/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Nutrition Section
+ 
+2.16.840.1.113883.10.20.22.2.57

--- a/Guide Examples/Nutritional Status Observation_2.16.840.1.113883.10.20.22.4.124/Nutritional Status Observation Example.xml
+++ b/Guide Examples/Nutritional Status Observation_2.16.840.1.113883.10.20.22.4.124/Nutritional Status Observation Example.xml
@@ -1,0 +1,32 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!--  Nutritional Status Observation -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.124" />
+  <id root="c12ecaaf-53f8-4593-8f79-359aeaa3948b" />
+  <code code="75305-3" 
+          displayName="Nutrition status"
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC">
+    <originalText>Nutritional Status</originalText>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime value="20130512" />
+  <value xsi:type="CD" code="248324001"
+          codeSystem="2.16.840.1.113883.6.96" 
+          codeSystemName="SNOMED-CT" 
+          displayName="well nourished" />
+  <entryRelationship typeCode="SUBJ">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Nutrition Assessment** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.138" /> 
+            ...
+        
+    </observation>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Nutrition Assessment** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.138" />
+            ...
+        
+    </observation>
+  </entryRelationship>
+</observation>
+    

--- a/Guide Examples/Nutritional Status Observation_2.16.840.1.113883.10.20.22.4.124/README.md
+++ b/Guide Examples/Nutritional Status Observation_2.16.840.1.113883.10.20.22.4.124/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Nutritional Status Observation
+ 
+2.16.840.1.113883.10.20.22.4.124

--- a/Guide Examples/Objective Section_2.16.840.1.113883.10.20.21.2.1/Objective Section Example.xml
+++ b/Guide Examples/Objective Section_2.16.840.1.113883.10.20.21.2.1/Objective Section Example.xml
@@ -1,0 +1,14 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.21.2.1"/>
+  <code	code="61149-1 " codeSystem="2.16.840.1.113883.6.1" 
+      codeSystemName="LOINC" 
+      displayName="OBJECTIVE DATA "/>
+  <title>OBJECTIVE DATA</title>
+  <text>
+    <list listType="ordered">
+      <item>Chest: clear to ausc. No rales, normal breath sounds</item>
+      <item>Heart: RR, PMI in normal location and no heave or evidence of
+              cardiomegaly,normal heart sounds, no murm or gallop</item>
+    </list>
+  </text>
+</section>

--- a/Guide Examples/Objective Section_2.16.840.1.113883.10.20.21.2.1/README.md
+++ b/Guide Examples/Objective Section_2.16.840.1.113883.10.20.21.2.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Objective Section
+ 
+2.16.840.1.113883.10.20.21.2.1

--- a/Guide Examples/Observer Context_2.16.840.1.113883.10.20.6.2.4/Observer Context Example.xml
+++ b/Guide Examples/Observer Context_2.16.840.1.113883.10.20.6.2.4/Observer Context Example.xml
@@ -1,0 +1,11 @@
+<assignedAuthor>
+  <templateId root="2.16.840.1.113883.10.20.6.2.4"/>
+  <id extension="121008" root="2.16.840.1.113883.19.5"/>
+  <assignedPerson>
+    <name>
+      <given>Richard</given>
+      <family>Blitz</family>
+      <suffix>MD</suffix>
+    </name>
+  </assignedPerson>
+</assignedAuthor>

--- a/Guide Examples/Observer Context_2.16.840.1.113883.10.20.6.2.4/README.md
+++ b/Guide Examples/Observer Context_2.16.840.1.113883.10.20.6.2.4/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Observer Context
+ 
+2.16.840.1.113883.10.20.6.2.4

--- a/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/Operative Note performer Example.xml
+++ b/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/Operative Note performer Example.xml
@@ -1,0 +1,22 @@
+ 
+<performer typeCode="PPRF">
+  <assignedEntity>
+    <id extension="1" root="2.16.840.1.113883.19" />
+    <code code="2086S0120X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" displayName="Pediatric Surgeon" />
+    <addr>
+      <streetAddressLine>1013 Healthcare Drive</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>99999</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(555)555-1013" />
+    <assignedPerson>
+      <name>
+        <prefix>Dr.</prefix>
+        <given>Carl</given>
+        <family>Cutter</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/Operative Note serviceEvent Example.xml
+++ b/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/Operative Note serviceEvent Example.xml
@@ -1,0 +1,12 @@
+ 
+
+<serviceEvent classCode="PROC">
+  <code code="801460020" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Laparoscopic Appendectomy" />
+  <effectiveTime>
+    <low value="201003292240" />
+    <width value="15" unit="m" />
+  </effectiveTime> 
+   ...
+ 
+
+</serviceEvent>

--- a/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/README.md
+++ b/Guide Examples/Operative Note (V3)_2.16.840.1.113883.10.20.22.1.7/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Operative Note (V3)
+ 
+2.16.840.1.113883.10.20.22.1.7

--- a/Guide Examples/Operative Note Fluids Section_2.16.840.1.113883.10.20.7.12/Operative Note Fluids Section Example.xml
+++ b/Guide Examples/Operative Note Fluids Section_2.16.840.1.113883.10.20.7.12/Operative Note Fluids Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.7.12"/>
+  <code code="10216-0" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="OPERATIVE NOTE FLUIDS"/>
+  <title>Operative Note Fluids</title>
+  <text>250 ML Ringers Lactate</text>
+</section>

--- a/Guide Examples/Operative Note Fluids Section_2.16.840.1.113883.10.20.7.12/README.md
+++ b/Guide Examples/Operative Note Fluids Section_2.16.840.1.113883.10.20.7.12/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Operative Note Fluids Section
+ 
+2.16.840.1.113883.10.20.7.12

--- a/Guide Examples/Operative Note Surgical Procedure Section_2.16.840.1.113883.10.20.7.14/Operative Note Surgical Procedure Section Example.xml
+++ b/Guide Examples/Operative Note Surgical Procedure Section_2.16.840.1.113883.10.20.7.14/Operative Note Surgical Procedure Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.7.14"/>
+  <code code="10223-6" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="OPERATIVE NOTE SURGICAL PROCEDURE"/>
+  <title>Surgical Procedure</title>
+  <text>Laparoscopic Appendectomy</text>
+</section>

--- a/Guide Examples/Operative Note Surgical Procedure Section_2.16.840.1.113883.10.20.7.14/README.md
+++ b/Guide Examples/Operative Note Surgical Procedure Section_2.16.840.1.113883.10.20.7.14/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Operative Note Surgical Procedure Section
+ 
+2.16.840.1.113883.10.20.7.14

--- a/Guide Examples/Outcome Observation_2.16.840.1.113883.10.20.22.4.144/Outcome Observation Example.xml
+++ b/Guide Examples/Outcome Observation_2.16.840.1.113883.10.20.22.4.144/Outcome Observation Example.xml
@@ -1,0 +1,21 @@
+<!-- Outcome Observation -->
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.144" />
+  <id root="0aaaa123-24e2-46b3-9d49-6b753c712dec" />
+  <code code="44616-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Pulse oximetry panel" />
+  <statusCode code="completed" />
+  <effectiveTime value="20130806" />
+  <value xsi:type="PQ" value="95" unit="%" />
+  <author>
+        ...
+    </author>
+  <!-- This Outcome Observation EVALUATES a Goal 
+    (Pulse ox reading of 95 evaluates the goal of Pulse ox reading > 92) -->
+  <entryRelationship typeCode="GEVL">
+        ...
+    </entryRelationship>
+  <!-- This Outcome Observation SUPPORTS the Progress Toward Goal Observation -->
+  <entryRelationship typeCode="SPRT" inversionInd="true">
+        ...
+    </entryRelationship>
+</observation>

--- a/Guide Examples/Outcome Observation_2.16.840.1.113883.10.20.22.4.144/README.md
+++ b/Guide Examples/Outcome Observation_2.16.840.1.113883.10.20.22.4.144/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Outcome Observation
+ 
+2.16.840.1.113883.10.20.22.4.144

--- a/Guide Examples/Past Medical History (V3)_2.16.840.1.113883.10.20.22.2.20/Past Medical History (V3) Example.xml
+++ b/Guide Examples/Past Medical History (V3)_2.16.840.1.113883.10.20.22.2.20/Past Medical History (V3) Example.xml
@@ -1,0 +1,18 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.20" extension="2015-08-01" />
+  <!-- ** History of Past Illness Section ** -->
+  <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="11348-0" displayName="HISTORY OF PAST ILLNESS" />
+  <title>PAST MEDICAL HISTORY</title>
+  <text>
+    <paragraph>Patient has had .....  </paragraph>
+  </text>
+  <entry>
+    <!-- Sample With Problem Observation. -->
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Problem Observation -->
+         ...
+      
+        
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Past Medical History (V3)_2.16.840.1.113883.10.20.22.2.20/README.md
+++ b/Guide Examples/Past Medical History (V3)_2.16.840.1.113883.10.20.22.2.20/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Past Medical History (V3)
+ 
+2.16.840.1.113883.10.20.22.2.20

--- a/Guide Examples/Patient Referral Act_2.16.840.1.113883.10.20.22.4.140/Patient Referral Act Example.xml
+++ b/Guide Examples/Patient Referral Act_2.16.840.1.113883.10.20.22.4.140/Patient Referral Act Example.xml
@@ -1,0 +1,42 @@
+<entry>
+  <act classCode="ACT" moodCode="INT">
+    <!--Patient Referral Act-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.140" />
+    <id root="70bdd7db-e02d-4eff-9829-35e3b7d9e154" />
+    <code code="44383000" displayName="Patient referral for consultation" codeSystemName="SNOMED" codeSystem="2.16.840.1.113883.6.96" />
+    <statusCode code="active" />
+    <effectiveTime value="20130311" />
+    <priorityCode code="A" 
+               codeSystem="2.16.840.1.113883.5.7" 
+               codeSystemName="ActPriority" 
+               displayName="ASAP"/>
+    <author>
+      <time value="200130311" />
+      <assignedAuthor>
+        <id extension="KP00017" root="2.16.840.1.113883.19.5" />
+        <addr>
+          <streetAddressLine>1003 Health Care
+                        Drive</streetAddressLine>
+          <city>Ann Arbor</city>
+          <state>MI</state>
+          <postalCode>02368</postalCode>
+          <country>US</country>
+        </addr>
+        <telecom use="WP" value="tel:(555)555-1003" />
+        <assignedPerson>
+          <name>
+            <given>Assigned</given>
+            <family>Amanda</family>
+          </name>
+        </assignedPerson>
+      </assignedAuthor>
+    </author>
+    <entryRelationship typeCode="SUBJ">
+      <observation classCode="OBS" moodCode="EVN">
+        <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+        <statusCode code="completed" />
+        <value xsi:type="CD" code="268528005" displayName="full care by specialist" codeSystem="2.16.840.1.113883.6.96" />
+      </observation>
+    </entryRelationship>
+  </act>
+</entry>

--- a/Guide Examples/Patient Referral Act_2.16.840.1.113883.10.20.22.4.140/README.md
+++ b/Guide Examples/Patient Referral Act_2.16.840.1.113883.10.20.22.4.140/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Patient Referral Act
+ 
+2.16.840.1.113883.10.20.22.4.140

--- a/Guide Examples/Payers Section (V3)_2.16.840.1.113883.10.20.22.2.18/Payers Section (V3) Example.xml
+++ b/Guide Examples/Payers Section (V3)_2.16.840.1.113883.10.20.22.2.18/Payers Section (V3) Example.xml
@@ -1,0 +1,21 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01" />
+  <!--  ******** Payers section template  ******** -->
+  <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payers" />
+  <title>Insurance Providers</title>
+  <text>
+        . . . 
+    </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="DEF">
+      <templateId root="2.16.840.1.113883.10.20.22.4.60" extension="2015-08-01" />
+      <!--  ****  Coverage entry template  **** -->
+      ...
+    
+        
+        
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Payers Section (V3)_2.16.840.1.113883.10.20.22.2.18/README.md
+++ b/Guide Examples/Payers Section (V3)_2.16.840.1.113883.10.20.22.2.18/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Payers Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.18

--- a/Guide Examples/Physical Exam Section (V3)_2.16.840.1.113883.10.20.2.10/Physical Exam Section (V3) Example.xml
+++ b/Guide Examples/Physical Exam Section (V3)_2.16.840.1.113883.10.20.2.10/Physical Exam Section (V3) Example.xml
@@ -1,0 +1,22 @@
+<component>
+  <section>
+    <templateId root="2.16.840.1.113883.10.20.2.10" extension="2015-08-01" />
+    <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="29545-1" displayName="Physical Findings" />
+    <title>Physical Examination</title>
+    <!--**10.4.1 Physical Exam at Transfer -->
+    <text>
+      <list listType="ordered">
+        <item>Recurrent GI bleed of unknown etiology; hypotension perhaps
+                    secondary to this but as likely secondary to polypharmacy.</item>
+        <item>Acute on chronic anemia secondary to #1.</item>
+        <item>Azotemia, acute renal failure with volume loss secondary to
+                    #1.</item>
+        <item>Hyperkalemia secondary to #3 and on ACE and K+ supplement.</item>
+        <item>Other chronic diagnoses as noted above, currently stable.</item>
+      </list>
+    </text>
+        ...
+    
+    
+  </section>
+</component>

--- a/Guide Examples/Physical Exam Section (V3)_2.16.840.1.113883.10.20.2.10/README.md
+++ b/Guide Examples/Physical Exam Section (V3)_2.16.840.1.113883.10.20.2.10/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Physical Exam Section (V3)
+ 
+2.16.840.1.113883.10.20.2.10

--- a/Guide Examples/Physician Reading Study Performer (V2)_2.16.840.1.113883.10.20.6.2.1/Physician Reading Study Performer (V2) Example.xml
+++ b/Guide Examples/Physician Reading Study Performer (V2)_2.16.840.1.113883.10.20.6.2.1/Physician Reading Study Performer (V2) Example.xml
@@ -1,0 +1,16 @@
+<performer typeCode="PRF">
+  <templateId root="2.16.840.1.113883.10.20.6.2.1" extension="2014-06-09" />
+  <assignedEntity>
+    <id extension="111111111" root="2.16.840.1.113883.4.6" />
+    <code code="2085R0202X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" displayName="Diagnostic Radiology" />
+    <addr nullFlavor="NI" />
+    <telecom nullFlavor="NI" />
+    <assignedPerson>
+      <name>
+        <given>Christine</given>
+        <family>Cure</family>
+        <suffix>MD</suffix>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/Physician Reading Study Performer (V2)_2.16.840.1.113883.10.20.6.2.1/README.md
+++ b/Guide Examples/Physician Reading Study Performer (V2)_2.16.840.1.113883.10.20.6.2.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Physician Reading Study Performer (V2)
+ 
+2.16.840.1.113883.10.20.6.2.1

--- a/Guide Examples/Physician of Record Participant (V2)_2.16.840.1.113883.10.20.6.2.2/Physician of Record Participant (V2) Example.xml
+++ b/Guide Examples/Physician of Record Participant (V2)_2.16.840.1.113883.10.20.6.2.2/Physician of Record Participant (V2) Example.xml
@@ -1,0 +1,16 @@
+<encounterParticipant typeCode="ATND">
+  <templateId root="2.16.840.1.113883.10.20.6.2.2" extension="2014-06-09" />
+  <assignedEntity>
+    <id extension="44444444" root="2.16.840.1.113883.4.6" />
+    <code code="208D00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" displayName="General Practice" />
+    <addr nullFlavor="NI" />
+    <telecom nullFlavor="NI" />
+    <assignedPerson>
+      <name>
+        <prefix>Dr.</prefix>
+        <given>Fay</given>
+        <family>Family</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</encounterParticipant>

--- a/Guide Examples/Physician of Record Participant (V2)_2.16.840.1.113883.10.20.6.2.2/README.md
+++ b/Guide Examples/Physician of Record Participant (V2)_2.16.840.1.113883.10.20.6.2.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Physician of Record Participant (V2)
+ 
+2.16.840.1.113883.10.20.6.2.2

--- a/Guide Examples/Plan of Treatment Section (V2)_2.16.840.1.113883.10.20.22.2.10/Plan of Treatment Section (V2) Example.xml
+++ b/Guide Examples/Plan of Treatment Section (V2)_2.16.840.1.113883.10.20.22.2.10/Plan of Treatment Section (V2) Example.xml
@@ -1,0 +1,31 @@
+<component>
+  <section>
+    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09" />
+    <!--  **** Plan of Treatment Section V2 template  **** -->
+    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Treatment plan" />
+    <title>TREATMENT PLAN</title>
+    <text>
+           ...
+        </text>
+    <entry>
+      <act classCode="ACT" moodCode="EVN">
+        <!-- Handoff Communication  template -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.141" />
+              ...
+            
+            
+      </act>
+    </entry>
+    <entry>
+      <encounter moodCode="INT" classCode="ENC">
+        <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09" />
+        <!-- Plan Activity Encounter V2 template -->
+              ...
+            
+                
+            
+      </encounter>
+    </entry>
+  </section>
+</component>
+    

--- a/Guide Examples/Plan of Treatment Section (V2)_2.16.840.1.113883.10.20.22.2.10/README.md
+++ b/Guide Examples/Plan of Treatment Section (V2)_2.16.840.1.113883.10.20.22.2.10/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Plan of Treatment Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.10

--- a/Guide Examples/Planned Act (V2)_2.16.840.1.113883.10.20.22.4.39/Planned Act (V2) Example.xml
+++ b/Guide Examples/Planned Act (V2)_2.16.840.1.113883.10.20.22.4.39/Planned Act (V2) Example.xml
@@ -1,0 +1,40 @@
+<act classCode="ACT" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.39" extension="2014-06-09" />
+  <id root="7658963e-54da-496f-bf18-dea1dddaa3b0" />
+  <code code="423171007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Elevate head of bed" />
+  <statusCode code="active" />
+  <effectiveTime value="20130902" />
+  <author typeCode="AUT">
+    <!-- Author Participation -->
+  </author>
+  <entryRelationship typeCode="RSON">
+    <!-- Patient Priority Preference -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Provider Priority Preference -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Indication (V2) -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ">
+    <!-- Instruction (V2) -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="COMP">
+    <!-- Planned Coverage -->
+    ...
+  
+    
+  </entryRelationship>
+</act>

--- a/Guide Examples/Planned Act (V2)_2.16.840.1.113883.10.20.22.4.39/README.md
+++ b/Guide Examples/Planned Act (V2)_2.16.840.1.113883.10.20.22.4.39/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Act (V2)
+ 
+2.16.840.1.113883.10.20.22.4.39

--- a/Guide Examples/Planned Coverage_2.16.840.1.113883.10.20.22.4.129/Planned Coverage Example.xml
+++ b/Guide Examples/Planned Coverage_2.16.840.1.113883.10.20.22.4.129/Planned Coverage Example.xml
@@ -1,0 +1,17 @@
+<act classCode="ACT" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.129" />
+  <id root="03f5e10b-7e79-4610-9626-d2984ff10cc1" />
+  <code code="48768-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Payment Sources" />
+  <statusCode code="active" />
+  <entryRelationship typeCode="COMP">
+    <act classCode="ACT" moodCode="INT">
+      <!-- These act/identifiers are unique identifiers 
+        for the policy or program providing the coverage. -->
+      <id root="4c9a3be1-5f09-46dd-88e7-14c8ec612e4c" />
+      <code code="111" displayName="Medicare HMO"
+                      codeSystemName="Source of Payment Typology (PHDSC)"
+                      codeSystem="2.16.840.1.113883.3.221.5" />
+      <statusCode code="active" />
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Planned Coverage_2.16.840.1.113883.10.20.22.4.129/README.md
+++ b/Guide Examples/Planned Coverage_2.16.840.1.113883.10.20.22.4.129/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Coverage
+ 
+2.16.840.1.113883.10.20.22.4.129

--- a/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/Planned Encounter (V2) Example.xml
+++ b/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/Planned Encounter (V2) Example.xml
@@ -1,0 +1,30 @@
+<entry>
+  <encounter moodCode="INT" classCode="ENC">
+    <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09" />
+    <!-- Planned Encounter V2 template -->
+    <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4d" />
+    <code code="185349003" displayName="encounter for check-up (procedure)" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96"></code>
+    <statusCode code="active" />
+    <effectiveTime value="20130615" />
+    <performer>
+      <assignedEntity>
+                ...
+            </assignedEntity>
+    </performer>
+    <entryRelationship typeCode="REFR">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Patient Priority Preference-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.142" />
+              ...
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="REFR">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Provider Priority Preference-->
+               ...
+            
+      </observation>
+    </entryRelationship>
+  </encounter>
+</entry>

--- a/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/README.md
+++ b/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Encounter (V2)
+ 
+2.16.840.1.113883.10.20.22.4.40

--- a/Guide Examples/Planned Immunization Activity_2.16.840.1.113883.10.20.22.4.120/Planned Immunization Activity.xml
+++ b/Guide Examples/Planned Immunization Activity_2.16.840.1.113883.10.20.22.4.120/Planned Immunization Activity.xml
@@ -1,0 +1,43 @@
+<substanceAdministration classCode="SBADM" moodCode="INT">
+  <!--  Planned Immunization Activity -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.120" />
+  <id root="81505d5e-2305-42b3-9273-f579d622000d" />
+  <statusCode code="active" />
+  <effectiveTime xsi:type="IVL_TS" value="20131115" />
+  <repeatNumber value="1" />
+  <routeCode code="IM" codeSystem="2.16.840.1.113883.5.112" codeSystemName="RouteOfAdministration" displayName="Intramuscular injection" />
+  <consumable>
+    <!-- Immunization Medication Information (V2) -->
+  </consumable>
+  <performer>
+        ...
+    </performer>
+  <author>
+    <!-- Author Participation -->
+  </author>
+  <entryRelationship typeCode="REFR">
+    <!-- Patient Priority Preference -->
+        ...
+    
+  </entryRelationship>
+  <entryRelationship typeCode="REFR">
+    <!-- Provider Priority Preference -->
+        ...
+    
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Indication (V2) -->
+        ...
+    
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ">
+    <!-- Instruction (V2) -->
+        ...
+    
+  </entryRelationship>
+  <precondition typeCode="PRCN">
+    <!-- Precondition for Substance Administration (V2) -->
+        ...
+    
+  </precondition>
+</substanceAdministration>

--- a/Guide Examples/Planned Immunization Activity_2.16.840.1.113883.10.20.22.4.120/README.md
+++ b/Guide Examples/Planned Immunization Activity_2.16.840.1.113883.10.20.22.4.120/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Immunization Activity
+ 
+2.16.840.1.113883.10.20.22.4.120

--- a/Guide Examples/Planned Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.42/Planned Medication Activity (V2) Example.xml
+++ b/Guide Examples/Planned Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.42/Planned Medication Activity (V2) Example.xml
@@ -1,0 +1,41 @@
+<substanceAdministration moodCode="INT" classCode="SBADM">
+  <templateId root="2.16.840.1.113883.10.20.22.4.42" extension="2014-06-09" />
+  <!-- Planned Medication Activity (V2)-->
+  <id root="cdbd33f0-6cde-11db-9fe1-0800200c9a66" />
+  <text>Heparin 0.25 ml Prefilled Syringe</text>
+  <statusCode code="active" />
+  <!-- The effectiveTime in a planned medication activity 
+    represents the time that the medication activity should occur. -->
+  <effectiveTime value="20130905" />
+  <consumable>
+    <manufacturedProduct classCode="MANU">
+      <!-- Medication Information (V2) -->
+      ...
+    
+    </manufacturedProduct>
+  </consumable>
+  <entryRelationship typeCode="REFR">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Patient Priority Preference-->
+      ...
+    
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="REFR">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Provider Priority Preference-->
+      ...
+    
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Indication (V2) -->
+    ...
+  
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ">
+    <!-- Instruction (V2) -->
+    ...
+  
+  </entryRelationship>
+</substanceAdministration>

--- a/Guide Examples/Planned Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.42/README.md
+++ b/Guide Examples/Planned Medication Activity (V2)_2.16.840.1.113883.10.20.22.4.42/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Medication Activity (V2)
+ 
+2.16.840.1.113883.10.20.22.4.42

--- a/Guide Examples/Planned Observation (V2)_2.16.840.1.113883.10.20.22.4.44/Planned Observation (V2) Example.xml
+++ b/Guide Examples/Planned Observation (V2)_2.16.840.1.113883.10.20.22.4.44/Planned Observation (V2) Example.xml
@@ -1,0 +1,38 @@
+<observation classCode="OBS" moodCode="INT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.44" 
+        extension="2014-06-09" />
+  <id root="b52bee94-c34b-4e2c-8c15-5ad9d6def205" />
+  <code code="59408-5" 
+        codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Oxygen saturation in Arterial blood by Pulse oximetry" />
+  <statusCode code="active" />
+  <effectiveTime value="20130903" />
+  <author typeCode="AUT">
+    <!-- Author Participation -->
+  </author>
+  <entryRelationship typeCode="REFR">
+    <!-- Priority Preference -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Indication (V2) -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ">
+    <!-- Instruction (V2) -->
+    ...
+  
+    
+  </entryRelationship>
+  <entryRelationship typeCode="COMP">
+    <!-- Planned Coverage -->
+    ...
+  
+    
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Planned Observation (V2)_2.16.840.1.113883.10.20.22.4.44/README.md
+++ b/Guide Examples/Planned Observation (V2)_2.16.840.1.113883.10.20.22.4.44/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.44

--- a/Guide Examples/Planned Procedure (V2)_2.16.840.1.113883.10.20.22.4.41/Planned Procedure (V2) Example.xml
+++ b/Guide Examples/Planned Procedure (V2)_2.16.840.1.113883.10.20.22.4.41/Planned Procedure (V2) Example.xml
@@ -1,0 +1,54 @@
+<entry>
+  <procedure moodCode="RQO" classCode="PROC">
+    <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09" />
+    <!-- **Planned Procedure (V2) template ** -->
+    <id root="9a6d1bac-17d3-4195-89c4-1121bc809b5a" />
+    <code code="73761001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Colonoscopy" />
+    <statusCode code="active" />
+    <effectiveTime value="20130613" />
+    <!-- Author Participation -->
+    <author typeCode="AUT">
+          ...
+        </author>
+    <entryRelationship typeCode="REFR">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Patient Priority Preference-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.142" />
+                ...								
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="REFR">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Provider Priority Preference-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+               ...
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="RSON">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Indication-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+               ...
+            
+      </observation>
+    </entryRelationship>
+    <entryRelationship typeCode="SUBJ">
+      <act classCode="ACT" moodCode="INT">
+        <!-- Instruction-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
+               ...
+            
+      </act>
+    </entryRelationship>
+    <entryRelationship typeCode="COMP">
+      <observation classCode="ACT" moodCode="INT">
+        <!-- Planned Coverage -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.129" />
+               ...
+            
+      </observation>
+    </entryRelationship>
+  </procedure>
+</entry>

--- a/Guide Examples/Planned Procedure (V2)_2.16.840.1.113883.10.20.22.4.41/README.md
+++ b/Guide Examples/Planned Procedure (V2)_2.16.840.1.113883.10.20.22.4.41/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Procedure (V2)
+ 
+2.16.840.1.113883.10.20.22.4.41

--- a/Guide Examples/Planned Procedure Section (V2)_2.16.840.1.113883.10.20.22.2.30/Planned Procedure Section (V2) Example.xml
+++ b/Guide Examples/Planned Procedure Section (V2)_2.16.840.1.113883.10.20.22.2.30/Planned Procedure Section (V2) Example.xml
@@ -1,0 +1,16 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.30" extension="2014-06-09" />
+  <code code="59772-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Planned Procedure" />
+  <title>Planned Procedure</title>
+  <text>
+      ...
+   </text>
+  <entry>
+    <procedure moodCode="RQO" classCode="PROC">
+      <templateId root="2.16.840.1.113883.10.20.22.4.41" extension="2014-06-09" />
+      <!-- ** Planned Procedure ** -->
+         ...
+      
+    </procedure>
+  </entry>
+</section>

--- a/Guide Examples/Planned Procedure Section (V2)_2.16.840.1.113883.10.20.22.2.30/README.md
+++ b/Guide Examples/Planned Procedure Section (V2)_2.16.840.1.113883.10.20.22.2.30/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Procedure Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.30

--- a/Guide Examples/Planned Supply (V2)_2.16.840.1.113883.10.20.22.4.43/Planned Supply (V2) Example.xml
+++ b/Guide Examples/Planned Supply (V2)_2.16.840.1.113883.10.20.22.4.43/Planned Supply (V2) Example.xml
@@ -1,0 +1,73 @@
+<supply moodCode="INT" classCode="SPLY">
+  <templateId root="2.16.840.1.113883.10.20.22.4.43" extension="2014-06-09" />
+  <!-- Planned Supply (V2) -->
+  <id root="9a6d1bac-17d3-4195-89c4-1121bc809b5d" />
+  <statusCode code="active" />
+  <!-- The effectiveTime in a planned supply represents 
+    the time that the supply should occur. -->
+  <effectiveTime value="20130615" />
+  <repeatNumber value="1" />
+  <quantity value="3" />
+  <!-- This product represents medication that is ordered, 
+    requested or intended for the patient. -->
+  <product>
+    <manufacturedProduct classCode="MANU">
+      <!-- Medication Information (V2) -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+      <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
+      <manufacturedMaterial>
+        <code code="573621" codeSystem="2.16.840.1.113883.6.88" displayName="Proventil 0.09 MG/ACTUAT inhalant solution">
+          <originalText>
+            <reference value="#MedSec_1" />
+          </originalText>
+          <translation code="573621" displayName="Proventil 0.09 MG/ACTUAT inhalant solution" codeSystem="2.16.840.1.113883.6.88" codeSystemName="RxNorm" />
+        </code>
+      </manufacturedMaterial>
+      <manufacturerOrganization>
+        <name>Medication Factory Inc.</name>
+      </manufacturerOrganization>
+    </manufacturedProduct>
+  </product>
+  <!-- The clinician who is expected to perform the supply 
+    could be identified using supply/performer. -->
+  <performer>
+    ...
+    
+  </performer>
+  <!-- The author in a supply represents the clinician 
+    who is requesting or planning the supply. -->
+  <author typeCode="AUT">
+    ...
+    
+  </author>
+  <entryRelationship typeCode="REFR">
+    <!-- Patient Priority Preference -->
+    ...
+    
+    
+  </entryRelationship>
+  <entryRelationship typeCode="REFR">
+    <!-- Provider Priority Preference -->
+    ...
+    
+    
+  </entryRelationship>
+  <entryRelationship typeCode="RSON">
+    <!-- Indication (V2) -->
+    ...
+    
+    
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ">
+    <!-- Instruction (V2) -->
+    ...
+    
+    
+  </entryRelationship>
+  <entryRelationship typeCode="COMP">
+    <!-- Planned Coverage -->
+    ...
+    
+    
+  </entryRelationship>
+</supply>

--- a/Guide Examples/Planned Supply (V2)_2.16.840.1.113883.10.20.22.4.43/README.md
+++ b/Guide Examples/Planned Supply (V2)_2.16.840.1.113883.10.20.22.4.43/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Planned Supply (V2)
+ 
+2.16.840.1.113883.10.20.22.4.43

--- a/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/Policy Activity (V3) Example.xml
+++ b/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/Policy Activity (V3) Example.xml
@@ -1,0 +1,122 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.61" extension="2015-08-01" />
+  <id root="3e676a50-7aac-11db-9fe1-0800200c9a66" />
+  <code code="12" displayName="Medicare Secondary Working Aged Beneficiary or Spouse with Employer Group Health Plan" 
+             codeSystemName="Insurance Type Code (x12N-1336)"
+             codeSystem="2.16.840.1.113883.6.255.1336">
+    <translation code="2" displayName="Medicare" 
+                                    codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology (PHDSC)"></translation>
+  </code>
+  <statusCode code="completed" />
+  <!-- Insurance company information -->
+  <performer typeCode="PRF">
+    <templateId root="2.16.840.1.113883.10.20.22.4.87" />
+    <time>
+      <low nullFlavor="UNK" />
+      <high nullFlavor="UNK" />
+    </time>
+    <assignedEntity>
+      <id root="2.16.840.1.113883.19" />
+      <code code="PAYOR" codeSystem="2.16.840.1.113883.5.110" codeSystemName="HL7 RoleCode" />
+      <addr use="WP">
+        <streetAddressLine>123 Insurance Road</streetAddressLine>
+        <city>Blue Bell</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+        <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      </addr>
+      <telecom value="tel:+(555)555-1515" use="WP" />
+      <representedOrganization>
+        <name>Good Health Insurance</name>
+        <telecom value="tel:+(555)555-1515" use="WP" />
+        <addr use="WP">
+          <streetAddressLine>123 Insurance Road</streetAddressLine>
+          <city>Blue Bell</city>
+          <state>MA</state>
+          <postalCode>02368</postalCode>
+          <country>US</country>
+        </addr>
+      </representedOrganization>
+    </assignedEntity>
+  </performer>
+  <!-- Guarantor information (the person responsible for the final bill) -->
+  <performer typeCode="PRF">
+    <templateId root="2.16.840.1.113883.10.20.22.4.88" />
+    <time>
+      <low nullFlavor="UNK" />
+      <high nullFlavor="UNK" />
+    </time>
+    <assignedEntity>
+      <id root="329fcdf0-7ab3-11db-9fe1-0800200c9a66" />
+      <code code="GUAR" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 RoleCode" />
+      <addr use="HP">
+        <streetAddressLine>17 Daws Rd.</streetAddressLine>
+        <city>Blue Bell</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom value="tel:+(781)555-1212" use="HP" />
+      <assignedPerson>
+        <name>
+          <prefix>Mr.</prefix>
+          <given>Adam</given>
+          <given>Frankie</given>
+          <family>Everyman</family>
+        </name>
+      </assignedPerson>
+    </assignedEntity>
+  </performer>
+  <!-- Covered party -->
+  <participant typeCode="COV">
+    <templateId root="2.16.840.1.113883.10.20.22.4.89.2" />
+    <time>
+      <low nullFlavor="UNK" />
+      <high nullFlavor="UNK" />
+    </time>
+    <participantRole classCode="PAT">
+      <!-- Health plan ID for patient. -->
+      <id root="1.1.1.1.1.1.1.1.14" extension="1138345" />
+      <code code="SELF" codeSystem="2.16.840.1.113883.5.111" />
+      <addr use="HP">
+        <streetAddressLine>17 Daws Rd.</streetAddressLine>
+        <city>Blue Bell</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+      </addr>
+      <playingEntity>
+        <name>
+          <!-- Name is needed if different than name on health plan. -->
+          <prefix>Mr.</prefix>
+          <given>Frank</given>
+          <given>A.</given>
+          <family>Everyman</family>
+        </name>
+      </playingEntity>
+    </participantRole>
+  </participant>
+  <!-- Policy holder -->
+  <participant typeCode="HLD">
+    <templateId root="2.16.840.1.113883.10.20.22.4.90.2" />
+    <participantRole>
+      <id extension="1138345" root="2.16.840.1.113883.19" />
+      <addr use="HP">
+        <streetAddressLine>17 Daws Rd.</streetAddressLine>
+        <city>Blue Bell</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>US</country>
+      </addr>
+    </participantRole>
+  </participant>
+  <entryRelationship typeCode="REFR">
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.1.19" />
+             . . .
+        
+        
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/README.md
+++ b/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Policy Activity (V3)
+ 
+2.16.840.1.113883.10.20.22.4.61

--- a/Guide Examples/Postoperative Diagnosis Section_2.16.840.1.113883.10.20.22.2.35/Postoperative Diagnosis Section Example.xml
+++ b/Guide Examples/Postoperative Diagnosis Section_2.16.840.1.113883.10.20.22.2.35/Postoperative Diagnosis Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.35"/>
+  <code code="10218-6" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="POSTOPERATIVE DIAGNOSIS"/>
+  <title>Postoperative Diagnosis</title>
+  <text>Appendicitis with periappendiceal abscess</text>
+</section>

--- a/Guide Examples/Postoperative Diagnosis Section_2.16.840.1.113883.10.20.22.2.35/README.md
+++ b/Guide Examples/Postoperative Diagnosis Section_2.16.840.1.113883.10.20.22.2.35/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Postoperative Diagnosis Section
+ 
+2.16.840.1.113883.10.20.22.2.35

--- a/Guide Examples/Postprocedure Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.51/Postprocedure Diagnosis (V3) Example.xml
+++ b/Guide Examples/Postprocedure Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.51/Postprocedure Diagnosis (V3) Example.xml
@@ -1,0 +1,20 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.36" extension="2015-08-01" />
+  <code code="59769-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="POSTPROCEDURE DIAGNOSIS" />
+  <title>Postprocedure Diagnosis</title>
+  <text>
+      ...
+   </text>
+  <entry>
+    <act moodCode="EVN" classCode="ACT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.51" extension="2015-08-01" />
+      <!-- ** Postprocedure Diagnosis ** -->
+         
+          ...
+      
+        
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Postprocedure Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.51/README.md
+++ b/Guide Examples/Postprocedure Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.51/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Postprocedure Diagnosis (V3)
+ 
+2.16.840.1.113883.10.20.22.4.51

--- a/Guide Examples/Postprocedure Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.36/Postprocedure Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Postprocedure Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.36/Postprocedure Diagnosis Section (V3) Example.xml
@@ -1,0 +1,19 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.36" extension="2015-08-01" />
+  <code code="59769-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="POSTPROCEDURE DIAGNOSIS" />
+  <title>Postprocedure Diagnosis</title>
+  <text>
+      ...
+   </text>
+  <entry>
+    <act moodCode="EVN" classCode="ACT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.51" extension="2014-06-09" />
+      <!-- ** Postprocedure Diagnosis ** -->
+         
+          ...
+      
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Postprocedure Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.36/README.md
+++ b/Guide Examples/Postprocedure Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.36/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Postprocedure Diagnosis Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.36

--- a/Guide Examples/Precondition for Substance Administration (V2)_2.16.840.1.113883.10.20.22.4.25/Precondition for Substance Administration (V2) Example.xml
+++ b/Guide Examples/Precondition for Substance Administration (V2)_2.16.840.1.113883.10.20.22.4.25/Precondition for Substance Administration (V2) Example.xml
@@ -1,0 +1,10 @@
+<criterion>
+  <templateId root="2.16.840.1.113883.10.20.22.4.25" 
+    extension="2014-06-09" />
+  <code code="ASSERTION" 
+    codeSystem="2.16.840.1.113883.5.4" />
+  <value xsi:type="CD" 
+    code="56018004" 
+    codeSystem="2.16.840.1.113883.6.96" 
+    displayName="Wheezing" />
+</criterion>

--- a/Guide Examples/Precondition for Substance Administration (V2)_2.16.840.1.113883.10.20.22.4.25/README.md
+++ b/Guide Examples/Precondition for Substance Administration (V2)_2.16.840.1.113883.10.20.22.4.25/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Precondition for Substance Administration (V2)
+ 
+2.16.840.1.113883.10.20.22.4.25

--- a/Guide Examples/Pregnancy Observation_2.16.840.1.113883.10.20.15.3.8/Pregnancy Observation Example.xml
+++ b/Guide Examples/Pregnancy Observation_2.16.840.1.113883.10.20.15.3.8/Pregnancy Observation Example.xml
@@ -1,0 +1,19 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.15.3.8"/>
+  <id extension="123456789" root="2.16.840.1.113883.19"/>
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+  <statusCode code="completed"/>
+  <effectiveTime>
+    <low value="20110410"/>
+  </effectiveTime>
+  <value xsi:type="CD" code="77386006" 
+         displayName="pregnant" 
+         codeSystem="2.16.840.1.113883.6.96"/>
+  <entryRelationship typeCode="REFR">
+    <templateId root="2.16.840.1.113883.10.20.15.3.1"/>
+
+    . . .
+
+  
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Pregnancy Observation_2.16.840.1.113883.10.20.15.3.8/README.md
+++ b/Guide Examples/Pregnancy Observation_2.16.840.1.113883.10.20.15.3.8/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Pregnancy Observation
+ 
+2.16.840.1.113883.10.20.15.3.8

--- a/Guide Examples/Preoperative Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.65/Preoperative Diagnosis (V3) Example.xml
+++ b/Guide Examples/Preoperative Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.65/Preoperative Diagnosis (V3) Example.xml
@@ -1,0 +1,13 @@
+<act moodCode="EVN" classCode="ACT">
+  <templateId root="2.16.840.1.113883.10.20.22.4.65" extension="2015-08-01" />
+  <code code="10219-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Preoperative Diagnosis" />
+  <entryRelationship typeCode="SUBJ">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+        . . .
+        
+        
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Preoperative Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.65/README.md
+++ b/Guide Examples/Preoperative Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.65/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Preoperative Diagnosis (V3)
+ 
+2.16.840.1.113883.10.20.22.4.65

--- a/Guide Examples/Preoperative Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.34/Preoperative Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Preoperative Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.34/Preoperative Diagnosis Section (V3) Example.xml
@@ -1,0 +1,17 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.34" extension="2015-08-01" />
+  <code code="10219-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName=" PREOPERATIVE DIAGNOSIS" />
+  <title>Preoperative Diagnosis</title>
+  <text>Appendicitis</text>
+  <entry>
+    <act moodCode="EVN" classCode="ACT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.65" extension="2015-08-01" />
+      <!-- ** Preoperative Diagnosis ** -->
+         ...
+      
+        
+        
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Preoperative Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.34/README.md
+++ b/Guide Examples/Preoperative Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.34/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Preoperative Diagnosis Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.34

--- a/Guide Examples/Priority Preference_2.16.840.1.113883.10.20.22.4.143/Priority Preference Example.xml
+++ b/Guide Examples/Priority Preference_2.16.840.1.113883.10.20.22.4.143/Priority Preference Example.xml
@@ -1,0 +1,27 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.143" />
+  <id root="7d66f448-ba82-4291-a9da-9e5db5e58803" />
+  <code code="225773000" 
+        codeSystem="2.16.840.1.113883.6.96" 
+        codeSystemName="SNOMED CT" 
+        displayName="preference" />
+  <value xsi:type="CD" 
+         code="394849002" 
+         codeSystem="2.16.840.1.113883.6.96" 
+         codeSystemName="SNOMED" 
+         displayName="High priority" />
+  <!--
+      Author Participation Template
+      In this case, the author is the same as a participant already described in the header. 
+      However, the author could be a the record target (patient), a different provider - 
+      someone else in the header, or a new provider not elsewhere specified.
+    -->
+  <author>
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    <time value="20130801" />
+    <assignedAuthor>
+      <!-- This id points back to a participant in the header -->
+      <id root="20cf14fb-b65c-4c8c-a54d-b0cca834c18c" />
+    </assignedAuthor>
+  </author>
+</observation>

--- a/Guide Examples/Priority Preference_2.16.840.1.113883.10.20.22.4.143/README.md
+++ b/Guide Examples/Priority Preference_2.16.840.1.113883.10.20.22.4.143/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Priority Preference
+ 
+2.16.840.1.113883.10.20.22.4.143

--- a/Guide Examples/Problem Concern Act (V3)_2.16.840.1.113883.10.20.22.4.3/Problem Concern Act (V3) Example.xml
+++ b/Guide Examples/Problem Concern Act (V3)_2.16.840.1.113883.10.20.22.4.3/Problem Concern Act (V3) Example.xml
@@ -1,0 +1,58 @@
+<act classCode="ACT" moodCode="EVN">
+  <!-- ** Problem Concern Act (V3) ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.3" 
+          extension="2015-08-01" />
+  <id root="ec8a6ff8-ed4b-4f7e-82c3-e98e58b45de7" />
+  <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+  <!-- The statusCode represents the need to continue tracking the problem -->
+  <!-- This is of ongoing concern to the provider -->
+  <statusCode code="active" />
+  <effectiveTime>
+    <!-- The low value represents when the problem was first recorded in the patient's chart -->
+    <!-- Concern was documented on July 6, 2013 -->
+    <low value="201307061145-0800" />
+  </effectiveTime>
+  <author typeCode="AUT">
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    <!-- Same as Concern effectiveTime/low -->
+    <time value="201307061145-0800" />
+    <assignedAuthor>
+      <id extension="555555555" root="2.16.840.1.113883.4.6" />
+      <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.6.101"
+        codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+    </assignedAuthor>
+  </author>
+  <entryRelationship typeCode="SUBJ">
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Problem Observation (V3) ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+      <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition" />
+      <!-- The statusCode reflects the status of the observation itself -->
+      <statusCode code="completed" />
+      <effectiveTime>
+        <!-- The low value reflects the date of onset -->
+        <!-- Based on patient symptoms, presumed onset is July 3, 2013 -->
+        <low value="20130703" />
+        <!-- The high value reflects when the problem was known to be resolved -->
+        <!-- Based on signs and symptoms, appears to be resolved on Aug 14, 2013 -->
+        <high value="20080814" />
+      </effectiveTime>
+      <value xsi:type="CD" 
+             code="233604007" 
+             codeSystem="2.16.840.1.113883.6.96"  
+             displayName="Pneumonia" />
+      <author typeCode="AUT">
+        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+        <time value="200808141030-0800" />
+        <assignedAuthor>
+          <id extension="555555555" root="2.16.840.1.113883.4.6" />
+          <code code="207QA0505X" 
+                displayName="Adult Medicine" 
+                codeSystem="2.16.840.1.113883.6.101"
+                codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+        </assignedAuthor>
+      </author>
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Problem Concern Act (V3)_2.16.840.1.113883.10.20.22.4.3/README.md
+++ b/Guide Examples/Problem Concern Act (V3)_2.16.840.1.113883.10.20.22.4.3/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Problem Concern Act (V3)
+ 
+2.16.840.1.113883.10.20.22.4.3

--- a/Guide Examples/Problem Observation (V3)_2.16.840.1.113883.10.20.22.4.4/Problem Observation (V3) Example.xml
+++ b/Guide Examples/Problem Observation (V3)_2.16.840.1.113883.10.20.22.4.4/Problem Observation (V3) Example.xml
@@ -1,0 +1,37 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- ** Problem Observation (V3) ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+  <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
+  <code code="64572001" displayName="Condition" 
+                                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+    <translation code="75323-6" 
+           codeSystem="2.16.840.1.113883.6.1" 
+           codeSystemName="LOINC" 
+           displayName="Condition"/>
+  </code>
+  <!-- The statusCode reflects the status of the observation itself -->
+  <statusCode code="completed" />
+  <effectiveTime>
+    <!-- The low value reflects the date of onset -->
+    <!-- Based on patient symptoms, presumed onset is July 3, 2013 -->
+    <low value="20130703" />
+    <!-- The high value reflects when the problem was known to be resolved -->
+    <!-- Based on signs and symptoms, appears to be resolved on Aug 14, 2013 -->
+    <high value="20080814" />
+  </effectiveTime>
+  <value xsi:type="CD" 
+    code="233604007" 
+    codeSystem="2.16.840.1.113883.6.96"  
+    displayName="Pneumonia" />
+  <author typeCode="AUT">
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    <time value="200808141030-0800" />
+    <assignedAuthor>
+      <id extension="555555555" root="2.16.840.1.113883.4.6" />
+      <code code="207QA0505X" 
+        displayName="Adult Medicine" 
+        codeSystem="2.16.840.1.113883.6.101"
+        codeSystemName="Healthcare Provider Taxonomy (HIPAA)" />
+    </assignedAuthor>
+  </author>
+</observation>

--- a/Guide Examples/Problem Observation (V3)_2.16.840.1.113883.10.20.22.4.4/README.md
+++ b/Guide Examples/Problem Observation (V3)_2.16.840.1.113883.10.20.22.4.4/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Problem Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.4

--- a/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/No Known Problems Section Example.xml
+++ b/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/No Known Problems Section Example.xml
@@ -1,0 +1,97 @@
+<section>
+  <!-- [C-CDA R2.1] Problem Section (entries optional) -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.5" extension="2015-08-01" />
+  <!-- [C-CDA R2.1] Problem Section (entries required) -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+  <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem List" />
+  <title>PROBLEMS</title>
+  <text ID="Concern_1">
+    Problem Concern:
+    
+    <br />
+    Concern Tracker Start Date: 06/07/2013 16:05:06
+    
+    <br />
+    Concern Tracker End Date: 
+    
+    <br />
+    Concern Status: Active    
+    
+    <br />
+    <content ID="problems1">No known 
+      
+      <content ID="problemType1">problems.</content>
+    </content>
+  </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="EVN">
+      <!-- [C-CDA R2.1] Problem Concern Act (V3) -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+      <id root="36e3e930-7b14-11db-9fe1-0800200c9a66" />
+      <!-- SDWG supports 48765-2 or CONC in the code element -->
+      <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
+      <text>
+        <reference value="#Concern_1" />
+      </text>
+      <statusCode code="active" />
+      <!-- The concern is not active, in terms of there being an active condition
+           to be managed.-->
+      <effectiveTime>
+        <low value="20130607160506" />
+        <!-- Time at which THIS �concern� began being tracked.-->
+      </effectiveTime>
+      <!-- status is active so high is not applicable. If high is present it 
+           should have nullFlavor of NA-->
+      <!-- Optional Author Element-->
+      <author>
+        <!--_ [C-CDA R2] Author Participation -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+        <time value="20130607160506" />
+        <assignedAuthor>
+          ...
+        </assignedAuthor>
+      </author>
+      <entryRelationship typeCode="SUBJ">
+        <observation classCode="OBS" moodCode="EVN" negationInd="true">
+          <!-- Model of Meaning for No Problems -->
+          <!-- This is more consistent with how we did no known allergies.
+               The use of negationInd corresponds with the newer 
+               Observation.ValueNegationInd.
+               The negationInd = true negates the value element. -->
+          <!-- [C-CDA R2.1] Problem Observation (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+          <id root="4adc1021-7b14-11db-9fe1-0800200c9a67" />
+          <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+          <text>
+            <reference value="#problems1" />
+          </text>
+          <statusCode code="completed" />
+          <effectiveTime>
+            <low value="20130607160506" />
+          </effectiveTime>
+          <!-- The time when this was biologically relevant ie True 
+               for the patient. As a minimum time interval over which 
+               this is true, populate the effectiveTime/low with the 
+               current time. 
+               It would be equally valid to have a longer range of 
+               time over which this statement was represented as 
+               being true. As a maximum, you would never indicate 
+               an effectiveTime/high that was greater than the 
+               current point in time. This idea assumes that the 
+               value element could come from the Problem value set, 
+               or when negationInd was true, is could also come from 
+               the ProblemType value set (and code would be ASSERTION). -->
+          <value xsi:type="CD" 
+                code="55607006" 
+                displayName="Problem" 
+                codeSystem="2.16.840.1.113883.6.96" 
+                codeSystemName="SNOMED CT">
+            <originalText>
+              <reference value="#problemType1" />
+            </originalText>
+          </value>
+        </observation>
+      </entryRelationship>
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/Problem Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/Problem Section (entries required) (V3) Example.xml
@@ -1,0 +1,26 @@
+<section>
+  <!-- [C-CDA R2.1] Problem Section (entries optional) -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.5" extension="2015-08-01" />
+  <!-- [C-CDA R2.1] Problem Section (entries required) -->
+  <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01" />
+  <code code="11450-4" 
+        codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="PROBLEM LIST" />
+  <title>PROBLEMS</title>
+  <text>
+    <list listType="ordered">
+      <item>Pneumonia: Resolved in March 1998</item>
+      <item>...</item>
+    </list>
+  </text>
+  <entry typeCode="DRIV">
+    <act classCode="ACT" moodCode="EVN">
+      <!-- [C-CDA R2.1] Problem Concern Act (V3) -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+      ...
+      
+    
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/README.md
+++ b/Guide Examples/Problem Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.5.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Problem Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.5.1

--- a/Guide Examples/Procedure Activity Act (V2)_2.16.840.1.113883.10.20.22.4.12/Procedure Activity Act Example.xml
+++ b/Guide Examples/Procedure Activity Act (V2)_2.16.840.1.113883.10.20.22.4.12/Procedure Activity Act Example.xml
@@ -1,0 +1,60 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.12" extension="2014-06-09" />
+  <id root="1.2.3.4.5.6.7.8" extension="1234567" />
+  <code code="274025005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Colonic polypectomy">
+    <originalText>
+      <reference value="#Proc1" />
+    </originalText>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime value="20110203" />
+  <priorityCode code="CR" codeSystem="2.16.840.1.113883.5.7" codeSystemName="ActPriority" displayName="Callback results" />
+  <performer>
+    <assignedEntity>
+      <id root="2.16.840.1.113883.19" extension="1234" />
+      <addr>
+        <streetAddressLine>1001 Village Avenue</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel: +1(555)-555-5000" />
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" />
+        <name>Community Health and Hospitals</name>
+        <telecom use="WP" value="tel:+1(555)-555-5000" />
+        <addr>
+          <streetAddressLine>1001 Village Avenue</streetAddressLine>
+          <city>Portland</city>
+          <state>OR</state>
+          <postalCode>99123</postalCode>
+          <country>US</country>
+        </addr>
+      </representedOrganization>
+    </assignedEntity>
+  </performer>
+  <participant typeCode="LOC">
+    <participantRole classCode="SDLOC">
+      <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+            . . .
+        
+    </participantRole>
+  </participant>
+  <entryRelationship typeCode="RSON">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+                . . . 
+
+        
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
+                . . .
+
+        
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Procedure Activity Act (V2)_2.16.840.1.113883.10.20.22.4.12/README.md
+++ b/Guide Examples/Procedure Activity Act (V2)_2.16.840.1.113883.10.20.22.4.12/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Activity Act (V2)
+ 
+2.16.840.1.113883.10.20.22.4.12

--- a/Guide Examples/Procedure Activity Observation (V2)_2.16.840.1.113883.10.20.22.4.13/Procedure Activity Observation (V2) Example.xml
+++ b/Guide Examples/Procedure Activity Observation (V2)_2.16.840.1.113883.10.20.22.4.13/Procedure Activity Observation (V2) Example.xml
@@ -1,0 +1,66 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09" />
+  <id extension="123456789" root="2.16.840.1.113883.19" />
+  <code code="274025005" 
+           codeSystem="2.16.840.1.113883.6.96" 
+           displayName="Colonic polypectomy" 
+           codeSystemName="SNOMED-CT">
+    <originalText>
+      <reference value="#Proc1" />
+    </originalText>
+  </code>
+  <statusCode code="aborted" />
+  <effectiveTime value="20110203" />
+  <priorityCode code="CR" codeSystem="2.16.840.1.113883.5.7" codeSystemName="ActPriority" displayName="Callback results" />
+  <value nullFlavor="NA" />
+  <methodCode nullFlavor="UNK" />
+  <targetSiteCode code="416949008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Abdomen and pelvis" />
+  <performer>
+    <assignedEntity>
+      <id root="2.16.840.1.113883.19" extension="1234" />
+      <addr>
+        <streetAddressLine>1001 Village Avenue</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel: +1(555)-555-5000" />
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5" />
+        <name>Community Health and Hospitals</name>
+        <telecom use="WP" value="tel:+1(555)-555-5000" />
+        <addr>
+          <streetAddressLine>1001 Village Avenue</streetAddressLine>
+          <city>Portland</city>
+          <state>OR</state>
+          <postalCode>99123</postalCode>
+          <country>US</country>
+        </addr>
+      </representedOrganization>
+    </assignedEntity>
+  </performer>
+  <participant typeCode="LOC">
+    <participantRole classCode="SDLOC">
+      <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+            . . .
+        
+    </participantRole>
+  </participant>
+  <entryRelationship typeCode="RSON">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+             . . .
+        
+        
+    </observation>
+  </entryRelationship>
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.20" extension="2014-06-09" />
+            . . .
+        
+        
+    </act>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Procedure Activity Observation (V2)_2.16.840.1.113883.10.20.22.4.13/README.md
+++ b/Guide Examples/Procedure Activity Observation (V2)_2.16.840.1.113883.10.20.22.4.13/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Activity Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.13

--- a/Guide Examples/Procedure Activity Procedure (V2)_2.16.840.1.113883.10.20.22.4.14/Procedure Activity Procedure (V2) Example.xml
+++ b/Guide Examples/Procedure Activity Procedure (V2)_2.16.840.1.113883.10.20.22.4.14/Procedure Activity Procedure (V2) Example.xml
@@ -1,0 +1,24 @@
+<procedure classCode="PROC" moodCode="EVN">
+  <!-- Procedure Activity Procedure V2-->
+  <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09" />
+  <id root="d5b614bd-01ce-410d-8726-e1fd01dcc72a" />
+  <code code="103716009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Stent Placement">
+    <originalText>
+      <reference value="#Proc1" />
+    </originalText>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime value="20130512" />
+  <targetSiteCode code="28273000" displayName="bile duct" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <specimen typeCode="SPC">
+    <specimenRole classCode="SPEC">
+      <id root="a6d7b927-2b70-43c7-bdf3-0e7c4133062c" />
+      <specimenPlayingEntity>
+        <code code="57259009" codeSystem="2.16.840.1.113883.6.96" displayName="gallbladder bile" />
+      </specimenPlayingEntity>
+    </specimenRole>
+  </specimen>
+  <performer>
+        ...
+    </performer>
+</procedure>

--- a/Guide Examples/Procedure Activity Procedure (V2)_2.16.840.1.113883.10.20.22.4.14/README.md
+++ b/Guide Examples/Procedure Activity Procedure (V2)_2.16.840.1.113883.10.20.22.4.14/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Activity Procedure (V2)
+ 
+2.16.840.1.113883.10.20.22.4.14

--- a/Guide Examples/Procedure Context_2.16.840.1.113883.10.20.6.2.5/Procedure Context Example.xml
+++ b/Guide Examples/Procedure Context_2.16.840.1.113883.10.20.6.2.5/Procedure Context Example.xml
@@ -1,0 +1,9 @@
+<act moodCode="EVN" classCode="ACT">
+  <templateId root="2.16.840.1.113883.10.20.6.2.5"/>
+  <code code="70548" 
+          displayName="Magnetic resonance angiography, head; with contrast material(s)"
+          codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4"/>
+  <!-- Note: This code is slightly different from the code used in the header 
+         documentationOf and overrides it, which is what this entry is for. -->
+  <effectiveTime value="20060823123529+0400"/>
+</act>

--- a/Guide Examples/Procedure Context_2.16.840.1.113883.10.20.6.2.5/README.md
+++ b/Guide Examples/Procedure Context_2.16.840.1.113883.10.20.6.2.5/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Context
+ 
+2.16.840.1.113883.10.20.6.2.5

--- a/Guide Examples/Procedure Description Section_2.16.840.1.113883.10.20.22.2.27/Procedure Description Section Example.xml
+++ b/Guide Examples/Procedure Description Section_2.16.840.1.113883.10.20.22.2.27/Procedure Description Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.27"/>
+  <code code="29554-3" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="PROCEDURE DESCRIPTION"/>
+  <title>Procedure Description</title>
+  <text>The patient was taken to the endoscopy suite where ... </text>
+</section>

--- a/Guide Examples/Procedure Description Section_2.16.840.1.113883.10.20.22.2.27/README.md
+++ b/Guide Examples/Procedure Description Section_2.16.840.1.113883.10.20.22.2.27/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Description Section
+ 
+2.16.840.1.113883.10.20.22.2.27

--- a/Guide Examples/Procedure Disposition Section_2.16.840.1.113883.10.20.18.2.12/Procedure Disposition Section Example.xml
+++ b/Guide Examples/Procedure Disposition Section_2.16.840.1.113883.10.20.18.2.12/Procedure Disposition Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.18.2.12"/>
+  <code code="59775-7" codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="PROCEDURE DISPOSITION"/>
+  <title>PROCEDURE DISPOSITION</title>
+  <text>The patient was taken to the Endoscopy Recovery Unit in stable
+        condition.</text>
+</section>

--- a/Guide Examples/Procedure Disposition Section_2.16.840.1.113883.10.20.18.2.12/README.md
+++ b/Guide Examples/Procedure Disposition Section_2.16.840.1.113883.10.20.18.2.12/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Disposition Section
+ 
+2.16.840.1.113883.10.20.18.2.12

--- a/Guide Examples/Procedure Estimated Blood Loss Section_2.16.840.1.113883.10.20.18.2.9/Procedure Estimated Blood Loss Section Example.xml
+++ b/Guide Examples/Procedure Estimated Blood Loss Section_2.16.840.1.113883.10.20.18.2.9/Procedure Estimated Blood Loss Section Example.xml
@@ -1,0 +1,7 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.18.2.9"/>
+  <code code="59770-8" codeSystem="2.16.840.1.113883.6.1" 
+      codeSystemName="LOINC" displayName="PROCEDURE ESTIMATED BLOOD LOSS"/>
+  <title>Procedure Estimated Blood Loss</title>
+  <text>Minimal</text>
+</section>

--- a/Guide Examples/Procedure Estimated Blood Loss Section_2.16.840.1.113883.10.20.18.2.9/README.md
+++ b/Guide Examples/Procedure Estimated Blood Loss Section_2.16.840.1.113883.10.20.18.2.9/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Estimated Blood Loss Section
+ 
+2.16.840.1.113883.10.20.18.2.9

--- a/Guide Examples/Procedure Findings Section (V3)_2.16.840.1.113883.10.20.22.2.28/Procedure Findings Section (V3) Example.xml
+++ b/Guide Examples/Procedure Findings Section (V3)_2.16.840.1.113883.10.20.22.2.28/Procedure Findings Section (V3) Example.xml
@@ -1,0 +1,16 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.28" extension="2015-08-01" />
+  <code code="59776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROCEDURE FINDINGS" />
+  <title>Procedure Findings</title>
+  <text>A 6 mm sessile polyp was found in the ascending colon and removed by snare, no cautery. Bleeding was controlled. Moderate diverticulosis  and hemorrhoids were incidentally noted.</text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2014-06-09" />
+      <!-- Problem Observation -->
+        ...
+      
+        
+        
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Procedure Findings Section (V3)_2.16.840.1.113883.10.20.22.2.28/README.md
+++ b/Guide Examples/Procedure Findings Section (V3)_2.16.840.1.113883.10.20.22.2.28/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Findings Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.28

--- a/Guide Examples/Procedure Implants Section_2.16.840.1.113883.10.20.22.2.40/Procedure Implants Section Example.xml
+++ b/Guide Examples/Procedure Implants Section_2.16.840.1.113883.10.20.22.2.40/Procedure Implants Section Example.xml
@@ -1,0 +1,7 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.40"/>
+  <code code="59771-6" codeSystem="2.16.840.1.113883.6.1" 
+      codeSystemName="LOINC" displayName="PROCEDURE IMPLANTS"/>
+  <title>Procedure Implants</title>
+  <text>No implants were placed.</text>
+</section>

--- a/Guide Examples/Procedure Implants Section_2.16.840.1.113883.10.20.22.2.40/README.md
+++ b/Guide Examples/Procedure Implants Section_2.16.840.1.113883.10.20.22.2.40/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Implants Section
+ 
+2.16.840.1.113883.10.20.22.2.40

--- a/Guide Examples/Procedure Indications Section (V2)_2.16.840.1.113883.10.20.22.2.29/Procedure Indications Section (V2) Example.xml
+++ b/Guide Examples/Procedure Indications Section (V2)_2.16.840.1.113883.10.20.22.2.29/Procedure Indications Section (V2) Example.xml
@@ -1,0 +1,16 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.29" extension="2014-06-09" />
+  <code code="59768-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROCEDURE INDICATIONS" />
+  <title>Procedure Indications</title>
+  <text>The procedure is performed for screening in a low risk individual.
+   </text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Indication Entry -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+         ...
+      
+        
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Procedure Indications Section (V2)_2.16.840.1.113883.10.20.22.2.29/README.md
+++ b/Guide Examples/Procedure Indications Section (V2)_2.16.840.1.113883.10.20.22.2.29/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Indications Section (V2)
+ 
+2.16.840.1.113883.10.20.22.2.29

--- a/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/Procedure Note performer Example.xml
+++ b/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/Procedure Note performer Example.xml
@@ -1,0 +1,21 @@
+<performer typeCode="PPRF">
+  <assignedEntity>
+    <id extension="IO00017" root="2.16.840.1.113883.19.5" />
+    <code code="207RG0100X" codeSystem="2.16.840.1.113883.6.96" codeSystemName="NUCC" displayName="Gastroenterologist" />
+    <addr>
+      <streetAddressLine>1001 Hospital Lane</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>99999</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(999)555-1212" />
+    <assignedPerson>
+      <name>
+        <prefix>Dr.</prefix>
+        <given>Tony</given>
+        <family>Tum</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/Procedure Note serviceEvent Example.xml
+++ b/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/Procedure Note serviceEvent Example.xml
@@ -1,0 +1,12 @@
+<documentationOf>
+  <serviceEvent classCode="PROC">
+    <code code="118155006" codeSystem="2.16.840.1.113883.6.96" 
+             codeSystemName="SNOMED CT" displayName="Gastrointestinal tract endoscopy" />
+    <effectiveTime>
+      <low value="201003292240" />
+      <width value="15" unit="m" />
+    </effectiveTime> 
+       ...
+    
+  </serviceEvent>
+</documentationOf>

--- a/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/README.md
+++ b/Guide Examples/Procedure Note (V3)_2.16.840.1.113883.10.20.22.1.6/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Note (V3)
+ 
+2.16.840.1.113883.10.20.22.1.6

--- a/Guide Examples/Procedure Specimens Taken Section_2.16.840.1.113883.10.20.22.2.31/Procedure Specimens Taken Section Example.xml
+++ b/Guide Examples/Procedure Specimens Taken Section_2.16.840.1.113883.10.20.22.2.31/Procedure Specimens Taken Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.31"/>
+  <code code="59773-2" 
+         codeSystem="2.16.840.1.113883.6.1" 
+         codeSystemName="LOINC" 
+         displayName="PROCEDURE SPECIMENS TAKEN"/>
+  <title>Procedure Specimens Taken</title>
+  <text>Ascending colon polyp</text>
+</section>

--- a/Guide Examples/Procedure Specimens Taken Section_2.16.840.1.113883.10.20.22.2.31/README.md
+++ b/Guide Examples/Procedure Specimens Taken Section_2.16.840.1.113883.10.20.22.2.31/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedure Specimens Taken Section
+ 
+2.16.840.1.113883.10.20.22.2.31

--- a/Guide Examples/Procedures Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.7.1/Procedures Section (entries required) (V2) Example.xml
+++ b/Guide Examples/Procedures Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.7.1/Procedures Section (entries required) (V2) Example.xml
@@ -1,0 +1,31 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.7" extension="2014-06-09" />
+  <!-- Procedures section template -->
+  <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="PROCEDURES" />
+  <title>Procedures</title>
+  <text>
+      ...
+    </text>
+  <entry typeCode="DRIV">
+    <procedure classCode="PROC" moodCode="EVN">
+      <!-- Procedure Activity Procedure template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.14" extension="2014-06-09" />
+          ...
+        
+    </procedure>
+  </entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09" />
+    <!-- Procedure Activity Observation template -->
+        ...
+    
+  </observation>
+  <entry>
+    <act classCode="ACT" moodCode="INT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.12" extension="2014-06-09" />
+      <!-- Procedure Activity Act template -->
+         ...
+        
+    </act>
+  </entry>
+</section>

--- a/Guide Examples/Procedures Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.7.1/README.md
+++ b/Guide Examples/Procedures Section (entries required) (V2)_2.16.840.1.113883.10.20.22.2.7.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Procedures Section (entries required) (V2)
+ 
+2.16.840.1.113883.10.20.22.2.7.1

--- a/Guide Examples/Product Instance_2.16.840.1.113883.10.20.22.4.37/Product Instance Example.xml
+++ b/Guide Examples/Product Instance_2.16.840.1.113883.10.20.22.4.37/Product Instance Example.xml
@@ -1,0 +1,13 @@
+<participantRole classCode="MANU">
+  <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+  <id root="2.16.840.1.113883.3.3719"   
+      extension="(01)51022222233336(11)141231(17)150707(10)A213B1(21)1234" 
+      assigningAuthorityName="FDA"/>
+  <playingDevice>
+    <code code="90412006" codeSystem="2.16.840.1.113883.6.96"   
+          displayName="Colonoscope"/>
+  </playingDevice>
+  <scopingEntity>
+    <id root="2.16.840.1.113883.3.3719"/>
+  </scopingEntity>
+</participantRole>

--- a/Guide Examples/Product Instance_2.16.840.1.113883.10.20.22.4.37/README.md
+++ b/Guide Examples/Product Instance_2.16.840.1.113883.10.20.22.4.37/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Product Instance
+ 
+2.16.840.1.113883.10.20.22.4.37

--- a/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis, Coded Example.xml
+++ b/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis, Coded Example.xml
@@ -1,0 +1,16 @@
+<entryRelationship typeCode="REFR">
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Prognosis -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.113" />
+    <id root="2097c709-291b-4a0f-bef9-ad9b23b3bb43" />
+    <code code="75328-5" 
+             codeSystem="2.16.840.1.113883.6.1" 
+             codeSystemName="LOINC" 
+             displayName="Prognosis" />
+    <statusCode code="completed" />
+    <effectiveTime>
+      <low value="20130301" />
+    </effectiveTime>
+    <value xsi:type="CD" code="67334001" codeSystem="2.16.840.1.113883.6.96" displayName="guarded prognosis" codeSystemName="SNOMED CT" />
+  </observation>
+</entryRelationship>

--- a/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis, Free Text Example.xml
+++ b/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/Prognosis, Free Text Example.xml
@@ -1,0 +1,15 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Prognosis -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.113" />
+  <id root="2097c709-291b-4a0f-bef9-ad9b23b3bb43" />
+  <code code="75328-5" 
+       codeSystem="2.16.840.1.113883.6.1" 
+       codeSystemName="LOINC" 
+       displayName="Prognosis" />
+  <text>
+        Presence of a life limiting condition(>50% possibility of death within 2 year)  
+    </text>
+  <statusCode code="completed" />
+  <effectiveTime value="20130606" />
+  <value xsi:type="ST">Presence of a life limiting condition(>50% possibility of death within 2 year</value>
+</observation>

--- a/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/README.md
+++ b/Guide Examples/Prognosis Observation_2.16.840.1.113883.10.20.22.4.113/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Prognosis Observation
+ 
+2.16.840.1.113883.10.20.22.4.113

--- a/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/Progress Note encompassingEncounter Example.xml
+++ b/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/Progress Note encompassingEncounter Example.xml
@@ -1,0 +1,16 @@
+<componentOf>
+  <encompassingEncounter>
+    <id extension="9937012" root="2.16.840.1.113883.19" />
+    <code codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4" code="99213" 
+               displayName="Evaluation and Management" />
+    <effectiveTime>
+      <low value="20090227130000+0500" />
+      <high value="20090227130000+0500" />
+    </effectiveTime>
+    <location>
+      <healthCareFacility>
+        <id root="2.16.540.1.113883.19.2" />
+      </healthCareFacility>
+    </location>
+  </encompassingEncounter>
+</componentOf>

--- a/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/Progress Note serviceEvent Example.xml
+++ b/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/Progress Note serviceEvent Example.xml
@@ -1,0 +1,11 @@
+<documentationOf>
+  <serviceEvent classCode="PCPR">
+    <templateId root="2.16.840.1.113883.10.20.21.3.1" />
+    <effectiveTime>
+      <low value="200503291200" />
+      <high value="200503291400" />
+    </effectiveTime>
+   ...
+  
+  </serviceEvent>
+</documentationOf>

--- a/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/README.md
+++ b/Guide Examples/Progress Note (V3)_2.16.840.1.113883.10.20.22.1.9/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Progress Note (V3)
+ 
+2.16.840.1.113883.10.20.22.1.9

--- a/Guide Examples/Progress Toward Goal Observation_2.16.840.1.113883.10.20.22.4.110/Progress Toward Goal Observation Example.xml
+++ b/Guide Examples/Progress Toward Goal Observation_2.16.840.1.113883.10.20.22.4.110/Progress Toward Goal Observation Example.xml
@@ -1,0 +1,6 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.110" />
+  <id root="2afcf057-aae4-47cf-bfee-b7498e300424" />
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+  <value xsi:type="CD" code="390802008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Goal achieved" />
+</observation>

--- a/Guide Examples/Progress Toward Goal Observation_2.16.840.1.113883.10.20.22.4.110/README.md
+++ b/Guide Examples/Progress Toward Goal Observation_2.16.840.1.113883.10.20.22.4.110/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Progress Toward Goal Observation
+ 
+2.16.840.1.113883.10.20.22.4.110

--- a/Guide Examples/Provenance - Assembler Participation_2.16.840.1.113883.10.20.22.5.7/Provenance - Author Participation.xml
+++ b/Guide Examples/Provenance - Assembler Participation_2.16.840.1.113883.10.20.22.5.7/Provenance - Author Participation.xml
@@ -1,0 +1,21 @@
+<participant typeCode="DEV">
+  <templateId root="2.16.840.1.113883.10.20.22.5.7" extension="2020-05-19" />
+  <functionCode code="assembler" codeSystem="2.16.840.1.113883.4.642.4.1131" 
+                codeSystemName="ProvenanceParticipantType"/>
+  <time value="20191206011130-0400" />
+  <associatedEntity classCode="OWN">
+    <scopingOrganization>
+      <!-- Represents the Assembler Organization -->
+      <id root="2.16.840.1.113883.19.5" extension="4"/>
+      <name use="L">Good Health HIE</name>
+      <telecom value="tel:+1(202)776-7700" use="WP" />
+      <addr use="WP">
+        <streetAddressLine partType="SAL">555 Badger Way</streetAddressLine>
+        <city partType="CTY">Amherst</city>
+        <state partType="STA">WI</state>
+        <postalCode partType="ZIP">01002</postalCode>
+        <country partType="CNT">US</country>
+      </addr>
+    </scopingOrganization>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Provenance - Assembler Participation_2.16.840.1.113883.10.20.22.5.7/README.md
+++ b/Guide Examples/Provenance - Assembler Participation_2.16.840.1.113883.10.20.22.5.7/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Provenance - Assembler Participation
+ 
+2.16.840.1.113883.10.20.22.5.7

--- a/Guide Examples/Provenance - Author Participation_2.16.840.1.113883.10.20.22.5.6/Provenance - Author Participation.xml
+++ b/Guide Examples/Provenance - Author Participation_2.16.840.1.113883.10.20.22.5.6/Provenance - Author Participation.xml
@@ -1,0 +1,24 @@
+<author>
+  <!-- Provenance - Author Participation -->
+  <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+  <time value="201308011235-0800"/>
+  <assignedAuthor>
+    <!-- NPI of Author (example) -->
+    <id root="2.16.840.1.113883.4.6" extension="1234567"/>
+    <assignedPerson>
+      <name>
+        <given>Nurse</given>
+        <family>Nightingale</family>
+        <suffix>RN</suffix>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+      <!-- Tax Identifier of Organization is Unknown -->
+      <id root="2.16.840.1.113883.5.1008" nullFlavor="UNK"/>
+      <!-- NPI of Organization -->
+      <id root="2.16.840.1.113883.4.6" extension="1104145838"/>
+      <name>Good Health Hospital</name>
+      <telecom value="tel:+1(555)867-5309"/>
+    </representedOrganization>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/Provenance - Author Participation_2.16.840.1.113883.10.20.22.5.6/README.md
+++ b/Guide Examples/Provenance - Author Participation_2.16.840.1.113883.10.20.22.5.6/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Provenance - Author Participation
+ 
+2.16.840.1.113883.10.20.22.5.6

--- a/Guide Examples/Purpose of Reference Observation_2.16.840.1.113883.10.20.6.2.9/Purpose of Reference Observation Example.xml
+++ b/Guide Examples/Purpose of Reference Observation_2.16.840.1.113883.10.20.6.2.9/Purpose of Reference Observation Example.xml
@@ -1,0 +1,7 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.9"/>
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"/>
+  <value xsi:type="CD" code="121112" codeSystem="1.2.840.10008.2.16.4"
+       codeSystemName="DCM"
+       displayName="Source of Measurement"/>
+</observation>

--- a/Guide Examples/Purpose of Reference Observation_2.16.840.1.113883.10.20.6.2.9/README.md
+++ b/Guide Examples/Purpose of Reference Observation_2.16.840.1.113883.10.20.6.2.9/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Purpose of Reference Observation
+ 
+2.16.840.1.113883.10.20.6.2.9

--- a/Guide Examples/Quantity Measurement Observation_2.16.840.1.113883.10.20.6.2.14/Quantity Measurement Observation Example.xml
+++ b/Guide Examples/Quantity Measurement Observation_2.16.840.1.113883.10.20.6.2.14/Quantity Measurement Observation Example.xml
@@ -1,0 +1,15 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.14"/>
+  <code code="439984002" codeSystem="2.16.840.1.113883.6.96" 
+        codeSystemName="SNM3" 
+        displayName="Diameter of structure">
+    <originalText>
+      <reference value="#Diam2"/>
+    </originalText>
+  </code>
+  <statusCode code="completed"/>
+  <effectiveTime value="200802260805-0800"/>
+  <value xsi:type="PQ" value="45" unit="mm"
+           codeSystemVersion="1.5"/>
+  <!-- entryRelationships to SOP Instance Observations may go here -->
+</observation>

--- a/Guide Examples/Quantity Measurement Observation_2.16.840.1.113883.10.20.6.2.14/README.md
+++ b/Guide Examples/Quantity Measurement Observation_2.16.840.1.113883.10.20.6.2.14/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Quantity Measurement Observation
+ 
+2.16.840.1.113883.10.20.6.2.14

--- a/Guide Examples/Reaction Observation (V2)_2.16.840.1.113883.10.20.22.4.9/README.md
+++ b/Guide Examples/Reaction Observation (V2)_2.16.840.1.113883.10.20.22.4.9/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Reaction Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.9

--- a/Guide Examples/Reaction Observation (V2)_2.16.840.1.113883.10.20.22.4.9/Reaction Observation (V2) Example.xml
+++ b/Guide Examples/Reaction Observation (V2)_2.16.840.1.113883.10.20.22.4.9/Reaction Observation (V2) Example.xml
@@ -1,0 +1,21 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.9" extension="2014-06-09" />
+  <id root="4adc1020-7b14-11db-9fe1-0800200c9a64" />
+  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+  <text>
+    <reference value="#reaction1" />
+  </text>
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="200802260805-0800" />
+    <high value="200802281205-0800" />
+  </effectiveTime>
+  <value xsi:type="CD" code="422587007" codeSystem="2.16.840.1.113883.6.96" displayName="Nausea" />
+  <entryRelationship typeCode="SUBJ" inversionInd="true">
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.8" extension="2014-06-09" />
+            . . .
+        
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Reason for Referral Section (V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/README.md
+++ b/Guide Examples/Reason for Referral Section (V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Reason for Referral Section (V2)
+ 
+1.3.6.1.4.1.19376.1.5.3.1.3.1

--- a/Guide Examples/Reason for Referral Section (V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/Reason for Referral Section (V2) Example.xml
+++ b/Guide Examples/Reason for Referral Section (V2)_1.3.6.1.4.1.19376.1.5.3.1.3.1/Reason for Referral Section (V2) Example.xml
@@ -1,0 +1,16 @@
+<component>
+  <section>
+    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09" />
+    <code code="42349-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Reason for Referral " />
+    <title>REASON FOR REFERRAL</title>
+    <text>Request for Patient referral for consultation.</text>
+    <entry>
+      <observation classCode="OBS" moodCode="INT">
+        <!-- Patient Referral Activity Observation -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.140" />
+                 ...					
+            
+      </observation>
+    </entry>
+  </section>
+</component>

--- a/Guide Examples/Reason for Visit Section_2.16.840.1.113883.10.20.22.2.12/README.md
+++ b/Guide Examples/Reason for Visit Section_2.16.840.1.113883.10.20.22.2.12/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Reason for Visit Section
+ 
+2.16.840.1.113883.10.20.22.2.12

--- a/Guide Examples/Reason for Visit Section_2.16.840.1.113883.10.20.22.2.12/Reason for Visit Section Example.xml
+++ b/Guide Examples/Reason for Visit Section_2.16.840.1.113883.10.20.22.2.12/Reason for Visit Section Example.xml
@@ -1,0 +1,11 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.12"/>
+  <code code="29299-5" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="REASON FOR VISIT"/>
+  <title>REASON FOR VISIT</title>
+  <text>
+    <paragraph>Dark stools.</paragraph>
+  </text>
+</section>

--- a/Guide Examples/Referenced Frames Observation_2.16.840.1.113883.10.20.6.2.10/README.md
+++ b/Guide Examples/Referenced Frames Observation_2.16.840.1.113883.10.20.6.2.10/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Referenced Frames Observation
+ 
+2.16.840.1.113883.10.20.6.2.10

--- a/Guide Examples/Referenced Frames Observation_2.16.840.1.113883.10.20.6.2.10/Referenced Frames Observation Example.xml
+++ b/Guide Examples/Referenced Frames Observation_2.16.840.1.113883.10.20.6.2.10/Referenced Frames Observation Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="ROIBND" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.10"/>
+  <code code="121190" codeSystem="1.2.840.10008.2.16.4" displayName="Referenced Frames"/>
+  <entryRelationship typeCode="COMP">
+    <!-- Boundary Observation -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.6.2.11"/>
+      <code code="113036" codeSystem="1.2.840.10008.2.16.4" displayName="Frames for Display"/>
+      <value xsi:type="INT" value="1"/>
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/README.md
+++ b/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Referral Note (V2)
+ 
+2.16.840.1.113883.10.20.22.1.14

--- a/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Callback Contact Example.xml
+++ b/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Callback Contact Example.xml
@@ -1,0 +1,22 @@
+<participant typeCode="CALLBCK">
+  <time value="20050329224411+0500" />
+  <associatedEntity classCode="ASSIGNED">
+    <id extension="99999999" root="2.16.840.1.113883.4.6" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <addr>
+      <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:555-555-1002" />
+    <associatedPerson>
+      <name>
+        <given>Henry</given>
+        <family>Seven</family>
+        <suffix>DO</suffix>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Caregiver Example.xml
+++ b/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Caregiver Example.xml
@@ -1,0 +1,22 @@
+<participant typeCode="IND">
+  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  <!-- Caregiver -->
+  <associatedEntity classCode="CAREGIVER">
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <addr>
+      <streetAddressLine>17 Daws Rd.</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel: 1+(555)555-1212" use="WP" />
+    <associatedPerson>
+      <name>
+        <prefix>Mrs.</prefix>
+        <given>Martha</given>
+        <family>Jones</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note informationRecipient Example.xml
+++ b/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note informationRecipient Example.xml
@@ -1,0 +1,23 @@
+<informationRecipient>
+  <intendedRecipient>
+    <informationRecipient>
+      <name>
+        <given>Nancy</given>
+        <family>Nightingale</family>
+        <suffix qualifier="AC">RN</suffix>
+      </name>
+    </informationRecipient>
+    <receivedOrganization>
+      <name>Community Health and Hospitals</name>
+      <telecom value="tel:+1(555)-555-1002" use="WP" />
+      <addr use="WP">
+        <streetAddressLine>Cardiac Stepdown Unit, 4B </streetAddressLine>
+        <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>97857</postalCode>
+        <country>US</country>
+      </addr>
+    </receivedOrganization>
+  </intendedRecipient>
+</informationRecipient>

--- a/Guide Examples/Result Observation (V3)_2.16.840.1.113883.10.20.22.4.2/README.md
+++ b/Guide Examples/Result Observation (V3)_2.16.840.1.113883.10.20.22.4.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Result Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.2

--- a/Guide Examples/Result Observation (V3)_2.16.840.1.113883.10.20.22.4.2/Result Observation (V3) Example.xml
+++ b/Guide Examples/Result Observation (V3)_2.16.840.1.113883.10.20.22.4.2/Result Observation (V3) Example.xml
@@ -1,0 +1,44 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+  <id root="7c0704bb-9c40-41b5-9c7d-26b2d59e234f" />
+  <code code="20570-8" displayName="Hematocrit" codeSystem="2.16.840.1.113883.6.1"
+codeSystemName="LOINC" />
+  <statusCode code="completed" />
+  <effectiveTime value="200803190830-0800" />
+  <value xsi:type="PQ" value="35.3" unit="%" />
+  <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83" />
+  <author>
+    <time value="200803190830-0800" />
+    <assignedAuthor>
+      <id extension="333444444" root="1.1.1.1.1.1.1.4" />
+      <addr>
+        <streetAddressLine>1017 Health Drive</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:+1(555)555-1017" />
+      <assignedPerson>
+        <name>
+          <given>William</given>
+          <given qualifier="CL">Bill</given>
+          <family>Beaker</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <name>Good Health Laboratory</name>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <referenceRange>
+    <observationRange>
+      <text>Low</text>
+      <value xsi:type="IVL_PQ">
+        <low value="34.9" unit="%" />
+        <high value="44.5" unit="%" />
+      </value>
+      <interpretationCode code="L" codeSystem="2.16.840.1.113883.5.83"/>
+    </observationRange>
+  </referenceRange>
+</observation>

--- a/Guide Examples/Result Organizer (V3)_2.16.840.1.113883.10.20.22.4.1/README.md
+++ b/Guide Examples/Result Organizer (V3)_2.16.840.1.113883.10.20.22.4.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Result Organizer (V3)
+ 
+2.16.840.1.113883.10.20.22.4.1

--- a/Guide Examples/Result Organizer (V3)_2.16.840.1.113883.10.20.22.4.1/Result Organizer (V3) Example.xml
+++ b/Guide Examples/Result Organizer (V3)_2.16.840.1.113883.10.20.22.4.1/Result Organizer (V3) Example.xml
@@ -1,0 +1,23 @@
+<organizer classCode="BATTERY" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01" />
+  <id root="7d5a02b0-67a4-11db-bd13-0800200c9a66" />
+  <code code="57021-8" displayName="CBC W Auto Differential panel in Blood" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="200803190830-0800" />
+    <high value="200803190830-0800" />
+  </effectiveTime>
+  <author>
+        . . .
+  </author>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- ** Result observation ** -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01" />
+            . . .
+        
+        
+        
+    </observation>
+  </component>
+</organizer>

--- a/Guide Examples/Results Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.3.1/README.md
+++ b/Guide Examples/Results Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.3.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Results Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.3.1

--- a/Guide Examples/Results Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.3.1/Results Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Results Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.3.1/Results Section (entries required) (V3) Example.xml
@@ -1,0 +1,28 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01" />
+  <code code="30954-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="RELEVANT DIAGNOSTIC TESTS AND/OR LABORATORY DATA" />
+  <title>Results</title>
+  <text />
+  <entry typeCode="DRIV">
+    <organizer classCode="BATTERY" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2014-06-09" />
+      ...
+    
+            
+            
+            
+            
+      <organizer>
+        <component>
+          <observation classCode="OBS" moodCode="EVN">
+            <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2014-06-09" />
+                        . . .
+                
+                    
+                    
+          </observation>
+        </component>
+      </organizer>
+    </organizer>
+  </entry>
+</section>

--- a/Guide Examples/Review of Systems Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/README.md
+++ b/Guide Examples/Review of Systems Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Review of Systems Section
+ 
+1.3.6.1.4.1.19376.1.5.3.1.3.18

--- a/Guide Examples/Review of Systems Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/Review of Systems Section Example.xml
+++ b/Guide Examples/Review of Systems Section_1.3.6.1.4.1.19376.1.5.3.1.3.18/Review of Systems Section Example.xml
@@ -1,0 +1,14 @@
+<section>
+  <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.18"/>
+  <code	code="10187-3" codeSystem="2.16.840.1.113883.6.1" 
+         codeSystemName="LOINC" 
+         displayName="REVIEW OF SYSTEMS"/>
+  <title>REVIEW OF SYSTEMS</title>
+  <text>
+    <paragraph>
+         Patient denies recent history of fever or malaise. Positive 
+         For weakness and shortness of breath. One episode of melena. No recent
+        headaches. Positive for osteoarthritis in hips, knees and hands.
+      </paragraph>
+  </text>
+</section>

--- a/Guide Examples/Risk Concern Act (V2)_2.16.840.1.113883.10.20.22.4.136/README.md
+++ b/Guide Examples/Risk Concern Act (V2)_2.16.840.1.113883.10.20.22.4.136/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Risk Concern Act (V2)
+ 
+2.16.840.1.113883.10.20.22.4.136

--- a/Guide Examples/Risk Concern Act (V2)_2.16.840.1.113883.10.20.22.4.136/Risk Concern Act Example.xml
+++ b/Guide Examples/Risk Concern Act (V2)_2.16.840.1.113883.10.20.22.4.136/Risk Concern Act Example.xml
@@ -1,0 +1,43 @@
+<!-- Risk Concern Act -->
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.136" extension="2015-08-01"/>
+  <id root="cbcbf20a-d011-449f-87d1-a23cc3e5f7cf" />
+  <code code="X-RISK-CONCERN-ACT" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="At risk for" />
+  <!-- This Health Risk has a statusCode of active because it is an active risk -->
+  <statusCode code="active" />
+  <!-- The effective time is the date that the Health Risk started being followed - 
+    this does not necessarily correlate to the onset date of the contained health issues-->
+  <effectiveTime value="20130616" />
+  <!-- Health Risk: Malignant neoplastic disease -->
+  <entryRelationship typeCode="REFR">
+    <!-- Problem Observation -->
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+      <id root="8dfacd73-1682-4cc4-9351-e54ccea83612" />
+      <code code="80943009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Risk factor" />
+      <statusCode code="completed" />
+      <effectiveTime>
+        <low value="20130613" />
+      </effectiveTime>
+      <value xsi:type="CD" code="409623005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Malignant neoplastic disease" />
+    </observation>
+  </entryRelationship>
+  ...
+  
+    
+    
+    
+  <!-- This entryRelationship represents the relationship 
+         "Health Risk REFERS TO Health Concern"
+    -->
+  <entryRelationship typeCode="REFR">
+    <!-- Entry Reference Concern Act -->
+    <act classCode="ACT" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+      <!-- This id points to an already defined Health Concern -->
+      <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
+      <code nullFlavor="NP" />
+      <statusCode code="completed" />
+    </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/README.md
+++ b/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+SOP Instance Observation
+ 
+2.16.840.1.113883.10.20.6.2.8

--- a/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/SOP Instance Observation Example.xml
+++ b/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/SOP Instance Observation Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="DGIMG" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.8"/>
+  <id root="1.2.840.113619.2.62.994044785528.20060823.200608232232322.3"/>
+  <code code="1.2.840.10008.5.1.4.1.1.1"
+codeSystem="1.2.840.10008.2.6.1" codeSystemName="DCMUID"
+displayName="Computed Radiography Image Storage"></code>
+  <text mediaType="application/dicom">
+    <reference value="http://www.example.org/wado?requestType=WADO&amp;studyUID=1.2.840.113619.2.62.994044785528.114289542805&amp;seriesUID=1.2.840.113619.2.62.994044785528.20060823223142485051&amp;objectUID=1.2.840.113619.2.62.994044785528.20060823.200608232232322.3&amp;contentType=application/dicom"/>
+    <!--reference to image 1 (PA) -->
+  </text>
+  <effectiveTime value="200608231235-0800"/>
+</observation>

--- a/Guide Examples/Section Time Range Observation_2.16.840.1.113883.10.20.22.4.201/README.md
+++ b/Guide Examples/Section Time Range Observation_2.16.840.1.113883.10.20.22.4.201/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Section Time Range Observation
+ 
+2.16.840.1.113883.10.20.22.4.201

--- a/Guide Examples/Section Time Range Observation_2.16.840.1.113883.10.20.22.4.201/Section Time Range Example.xml
+++ b/Guide Examples/Section Time Range Observation_2.16.840.1.113883.10.20.22.4.201/Section Time Range Example.xml
@@ -1,0 +1,14 @@
+<!--  Section Time Range Observation -->
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.68.99999"/>
+  <code code="X-SECTIONTIMERANGE" codeSystem="2.16.840.1.113883.6.1" 
+                displayName="Section Date and Time Range"/>
+  <text>
+    <reference value="#TS_Narrative1"/>
+  </text>
+  <statusCode code="completed"/>
+  <value xsi:type="IVL_TS">
+    <low value="20120815"/>
+    <high value="20150815"/>
+  </value>
+</observation>

--- a/Guide Examples/Self-Care Activities (ADL and IADL)_2.16.840.1.113883.10.20.22.4.128/README.md
+++ b/Guide Examples/Self-Care Activities (ADL and IADL)_2.16.840.1.113883.10.20.22.4.128/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Self-Care Activities (ADL and IADL)
+ 
+2.16.840.1.113883.10.20.22.4.128

--- a/Guide Examples/Self-Care Activities (ADL and IADL)_2.16.840.1.113883.10.20.22.4.128/Self-Care Activities (ADL and IADL) Example.xml
+++ b/Guide Examples/Self-Care Activities (ADL and IADL)_2.16.840.1.113883.10.20.22.4.128/Self-Care Activities (ADL and IADL) Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- Self Care Activities (NEW)-->
+  <templateId root="2.16.840.1.113883.10.20.22.4.128" />
+  <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0a" />
+  <code code="46482-6" displayName="Transferring" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <statusCode code="completed" />
+  <effectiveTime value="200130311" />
+  <value xsi:type="CD" code="371153006" displayName="Independent" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+  <author>
+       ...
+    </author>
+</observation>

--- a/Guide Examples/Sensory Status_2.16.840.1.113883.10.20.22.4.127/README.md
+++ b/Guide Examples/Sensory Status_2.16.840.1.113883.10.20.22.4.127/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Sensory Status
+ 
+2.16.840.1.113883.10.20.22.4.127

--- a/Guide Examples/Sensory Status_2.16.840.1.113883.10.20.22.4.127/Sensory and Speech Status Example.xml
+++ b/Guide Examples/Sensory Status_2.16.840.1.113883.10.20.22.4.127/Sensory and Speech Status Example.xml
@@ -1,0 +1,21 @@
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Sensory and Speech Status(NEW)-->
+    <templateId root="2.16.840.1.113883.10.20.22.4.127" />
+    <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0a" />
+    <code code="47078008" displayName="Hearing" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <statusCode code="completed" />
+    <effectiveTime value="200130311" />
+    <value xsi:type="CD" code="260379002" displayName="Impaired" codeSystemName="SNOMED CT" />
+    <entryRelationship typeCode="COMP">
+      <observation classCode="OBS" moodCode="EVN">
+        <!--Assessment Scale Observation -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.69" />
+        <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0b" />
+               ...
+            
+            
+      </observation>
+    </entryRelationship>
+  </observation>
+</entry>

--- a/Guide Examples/Serial Number Observation_2.16.840.1.113883.10.20.22.4.319/README.md
+++ b/Guide Examples/Serial Number Observation_2.16.840.1.113883.10.20.22.4.319/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Serial Number Observation
+ 
+2.16.840.1.113883.10.20.22.4.319

--- a/Guide Examples/Serial Number Observation_2.16.840.1.113883.10.20.22.4.319/Serial Number Example.xml
+++ b/Guide Examples/Serial Number Observation_2.16.840.1.113883.10.20.22.4.319/Serial Number Example.xml
@@ -1,0 +1,8 @@
+<observation classCode="OBS" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.319" extension="2019-06-21"/>
+	<code code="C101671" displayName="Serial Number"
+ codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
+	<value xsi:type="ED">
+		<reference value="#SerialNumber_1"/>
+	</value>
+</observation>

--- a/Guide Examples/Series Act_2.16.840.1.113883.10.20.22.4.63/README.md
+++ b/Guide Examples/Series Act_2.16.840.1.113883.10.20.22.4.63/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Series Act
+ 
+2.16.840.1.113883.10.20.22.4.63

--- a/Guide Examples/Series Act_2.16.840.1.113883.10.20.22.4.63/Series Act Example.xml
+++ b/Guide Examples/Series Act_2.16.840.1.113883.10.20.22.4.63/Series Act Example.xml
@@ -1,0 +1,22 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.63"/>
+  <id root="1.2.840.113619.2.62.994044785528.20060823223142485051"/>
+  <code code="113015" codeSystem="1.2.840.10008.2.16.4"
+          codeSystemName="DCM" displayName="Series">
+    <qualifier>
+      <name code="121139" codeSystem="1.2.840.10008.2.16.4"
+                  codeSystemName="DCM" displayName="Modality"/>
+      <value code="CR" codeSystem="1.2.840.10008.2.16.4" codeSystemName="DCM"
+                   displayName="Computed Radiography"/>
+    </qualifier>
+  </code>
+  <!-- **** SOP Instance UID *** -->
+  <entryRelationship typeCode="COMP">
+    <observation classCode="DGIMG" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.6.2.8"/>
+...
+
+        
+    </observation>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Service Delivery Location_2.16.840.1.113883.10.20.22.4.32/README.md
+++ b/Guide Examples/Service Delivery Location_2.16.840.1.113883.10.20.22.4.32/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Service Delivery Location
+ 
+2.16.840.1.113883.10.20.22.4.32

--- a/Guide Examples/Service Delivery Location_2.16.840.1.113883.10.20.22.4.32/Service Delivery Location Example.xml
+++ b/Guide Examples/Service Delivery Location_2.16.840.1.113883.10.20.22.4.32/Service Delivery Location Example.xml
@@ -1,0 +1,16 @@
+<participantRole classCode="SDLOC">
+  <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+  <code code="1160-1" codeSystem="2.16.840.1.113883.6.259"
+          codeSystemName="HealthcareServiceLocation" displayName="Urgent Care Center"/>
+  <addr>
+    <streetAddressLine>17 Daws Rd.</streetAddressLine>
+    <city>Blue Bell</city>
+    <state>MA</state>
+    <postalCode>02368</postalCode>
+    <country>US</country>
+  </addr>
+  <telecom use="WP" value="tel:+1(555)555-5000"/>
+  <playingEntity classCode="PLC">
+    <name>Community Health and Hospitals</name>
+  </playingEntity>
+</participantRole>

--- a/Guide Examples/Severity Observation (V2)_2.16.840.1.113883.10.20.22.4.8/README.md
+++ b/Guide Examples/Severity Observation (V2)_2.16.840.1.113883.10.20.22.4.8/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Severity Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.8

--- a/Guide Examples/Severity Observation (V2)_2.16.840.1.113883.10.20.22.4.8/Severity Observation (V2) Example.xml
+++ b/Guide Examples/Severity Observation (V2)_2.16.840.1.113883.10.20.22.4.8/Severity Observation (V2) Example.xml
@@ -1,0 +1,9 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.8" extension="2014-06-09" />
+  <code code="SEV" displayName="Severity Observation" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" />
+  <text>
+    <reference value="#allergyseverity1" />
+  </text>
+  <statusCode code="completed" />
+  <value xsi:type="CD" code="371924009" displayName="Moderate to severe" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+</observation>

--- a/Guide Examples/Smoking Status - Meaningful Use (V2)_2.16.840.1.113883.10.20.22.4.78/README.md
+++ b/Guide Examples/Smoking Status - Meaningful Use (V2)_2.16.840.1.113883.10.20.22.4.78/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Smoking Status - Meaningful Use (V2)
+ 
+2.16.840.1.113883.10.20.22.4.78

--- a/Guide Examples/Smoking Status - Meaningful Use (V2)_2.16.840.1.113883.10.20.22.4.78/Smoking Status - Meaningful Use (V2) Example.xml
+++ b/Guide Examples/Smoking Status - Meaningful Use (V2)_2.16.840.1.113883.10.20.22.4.78/Smoking Status - Meaningful Use (V2) Example.xml
@@ -1,0 +1,16 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.78" extension="2014-06-09" />
+  <id extension="123456789" root="2.16.840.1.113883.19" />
+  <code code="72166-2" codeSystem="2.16.840.1.113883.6.1" displayName="Tobacco smoking status NHIS" />
+  <statusCode code="completed" />
+  <!-- The effectiveTime reflects when the current smoking status was observed. -->
+  <effectiveTime value="20120910" />
+  <!-- The value represents the patient's smoking status currently observed. -->
+  <value xsi:type="CD" code="8517006" displayName="Former smoker" codeSystem="2.16.840.1.113883.6.96" />
+  <author typeCode="AUT">
+    <time value="199803161030-0800" />
+    <assignedAuthor>
+      <id extension="555555555" root="1.1.1.1.1.1.1.2" />
+    </assignedAuthor>
+  </author>
+</observation>

--- a/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/README.md
+++ b/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Social History Observation (V3)
+ 
+2.16.840.1.113883.10.20.22.4.38

--- a/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
+++ b/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
@@ -1,0 +1,23 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.38" 
+        extension="2015-08-01" />
+  <id root="37f76c51-6411-4e1d-8a37-957fd49d2cef" />
+  <code code="160573003" displayName="Alcohol intake" 
+                                codeSystem="2.16.840.1.113883.6.96"  
+                                codeSystemName="SNOMED CT">
+    <translation code="74013-4"  
+        codeSystem="2.16.840.1.113883.6.1" 
+        codeSystemName="LOINC" 
+        displayName="Alcoholic drinks per day"></translation>
+    <statusCode code="completed" />
+    <effectiveTime>
+      <low value="20120215" />
+    </effectiveTime>
+    <value xsi:type="PQ" value="12" />
+    <author typeCode="AUT">
+      <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    ...
+  
+        
+    </author>
+  </observation>

--- a/Guide Examples/Social History Section (V3)_2.16.840.1.113883.10.20.22.2.17/README.md
+++ b/Guide Examples/Social History Section (V3)_2.16.840.1.113883.10.20.22.2.17/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Social History Section (V3)
+ 
+2.16.840.1.113883.10.20.22.2.17

--- a/Guide Examples/Social History Section (V3)_2.16.840.1.113883.10.20.22.2.17/Social History Section (V3) Example.xml
+++ b/Guide Examples/Social History Section (V3)_2.16.840.1.113883.10.20.22.2.17/Social History Section (V3) Example.xml
@@ -1,0 +1,64 @@
+<component>
+  <section>
+    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01" />
+    <code code="29762-2" codeSystem="2.16.840.1.113883.6.1" displayName="Social History" />
+    <title>SOCIAL HISTORY</title>
+    <text>
+        . . .
+        </text>
+    <entry>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Social history observation V2-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.38" extension="2015-08-01" />							
+       ...
+          
+            
+            
+      </observation>
+    </entry>
+    <entry>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- ** Current smoking status observation ** -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.78" extension="2014-06-09" />
+	 ...
+          
+            
+            
+            
+      </observation>
+    </entry>
+    <entry>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Caregiver Characteristics -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.72" />
+       ...
+    
+            
+            
+            
+      </observation>
+    </entry>
+    <entry>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- **Cultural and Religious Observations(NEW)**-->
+        <templateId root="2.16.840.1.113883.10.20.22.4.111" />
+        ...
+    
+            
+            
+            
+      </observation>
+    </entry>
+    <entry>
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- ** Characteristics of Care Environment** -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.109" />
+       ...
+    
+            
+            
+            
+      </observation>
+    </entry>
+  </section>
+</component>

--- a/Guide Examples/Study Act_2.16.840.1.113883.10.20.6.2.6/README.md
+++ b/Guide Examples/Study Act_2.16.840.1.113883.10.20.6.2.6/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Study Act
+ 
+2.16.840.1.113883.10.20.6.2.6

--- a/Guide Examples/Study Act_2.16.840.1.113883.10.20.6.2.6/Study Act Example.xml
+++ b/Guide Examples/Study Act_2.16.840.1.113883.10.20.6.2.6/Study Act Example.xml
@@ -1,0 +1,13 @@
+<act classCode="ACT" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.6.2.6"/>
+  <id root="1.2.840.113619.2.62.994044785528.114289542805"/>
+  <code code="113014" codeSystem="1.2.840.10008.2.16.4" codeSystemName="DCM" displayName="Study"/>
+  <!-- **** Series ****-->
+  <entryRelationship typeCode="COMP">
+    <act classCode="ACT" moodCode="EVN">
+
+         . . .
+
+        </act>
+  </entryRelationship>
+</act>

--- a/Guide Examples/Subjective Section_2.16.840.1.113883.10.20.21.2.2/README.md
+++ b/Guide Examples/Subjective Section_2.16.840.1.113883.10.20.21.2.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Subjective Section
+ 
+2.16.840.1.113883.10.20.21.2.2

--- a/Guide Examples/Subjective Section_2.16.840.1.113883.10.20.21.2.2/Subjective Section Example.xml
+++ b/Guide Examples/Subjective Section_2.16.840.1.113883.10.20.21.2.2/Subjective Section Example.xml
@@ -1,0 +1,18 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.21.2.2"/>
+  <code	code="61150-9" codeSystem="2.16.840.1.113883.6.1" 
+         codeSystemName="LOINC" 
+         displayName="SUBJECTIVE"/>
+  <title>SUBJECTIVE DATA</title>
+  <text>
+    <paragraph>
+       I have used the peripheral nerve stimulator in my back for five days. 
+        While using it I found that I was able to do physical activity 
+        without pain. However, afterwards for one day, I would feel pain but 
+        then it would go away. I also noticed that I didn�t have to take the 
+        Vicodin as much. I took 2 less Vicodin per day and 2 less tramadol 
+        everyday. I have not lain in my bed in a year and a half. I sleep in 
+        a recliner. 
+      </paragraph>
+  </text>
+</section>

--- a/Guide Examples/Substance Administered Act_2.16.840.1.113883.10.20.22.4.118/README.md
+++ b/Guide Examples/Substance Administered Act_2.16.840.1.113883.10.20.22.4.118/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Substance Administered Act
+ 
+2.16.840.1.113883.10.20.22.4.118

--- a/Guide Examples/Substance Administered Act_2.16.840.1.113883.10.20.22.4.118/Substance Administered Act Example.xml
+++ b/Guide Examples/Substance Administered Act_2.16.840.1.113883.10.20.22.4.118/Substance Administered Act Example.xml
@@ -1,0 +1,26 @@
+<substanceAdministration classCode="SBADM" moodCode="EVN">
+    ...
+
+    
+  <consumable>
+               ...
+
+        
+    <code code="43" codeSystem="2.16.840.1.113883.6.59" displayName="Hepatitis B Vaccine" codeSystemName="CVX" />
+  </consumable>
+  <entryRelationship typeCode="COMP">
+    <!-- This entryRelationship sequenceNumber indicates this is #2 in the series -->
+    <sequenceNumber value="2" />
+    <act classCode="ACT" moodCode="EVN">
+      <!-- Substance Administered Act Template -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.118" />
+      <id root="df8908d0-40f2-11e3-aa6e-0800200c9a66" />
+      <code code="416118004" displayName="administration" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+      <statusCode code="completed" />
+      <effectiveTime value="19991101" />
+    </act>
+  </entryRelationship>
+        ...
+
+
+</substanceAdministration>

--- a/Guide Examples/Surgical Drains Section_2.16.840.1.113883.10.20.7.13/README.md
+++ b/Guide Examples/Surgical Drains Section_2.16.840.1.113883.10.20.7.13/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Surgical Drains Section
+ 
+2.16.840.1.113883.10.20.7.13

--- a/Guide Examples/Surgical Drains Section_2.16.840.1.113883.10.20.7.13/Surgical Drains Section Example.xml
+++ b/Guide Examples/Surgical Drains Section_2.16.840.1.113883.10.20.7.13/Surgical Drains Section Example.xml
@@ -1,0 +1,9 @@
+<section>
+  <templateId root="2.16.840.1.113883.10.20.7.13"/>
+  <code code="11537-8" 
+          codeSystem="2.16.840.1.113883.6.1" 
+          codeSystemName="LOINC" 
+          displayName="SURGICAL DRAINS"/>
+  <title>Surgical Drains</title>
+  <text>Penrose drain placed</text>
+</section>

--- a/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/README.md
+++ b/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Text Observation
+ 
+2.16.840.1.113883.10.20.6.2.12

--- a/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/Text Observation Example.xml
+++ b/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/Text Observation Example.xml
@@ -1,0 +1,25 @@
+<text>
+  <paragraph>
+    <caption>Finding</caption>
+    <content ID="Fndng2">The cardiomediastinum is within normal limits. The trachea is midline. The previously described opacity at the medial right lung base has cleared. There are no new infiltrates. There is a new round density at the left hilus, superiorly (diameter about 45mm). A CT scan is recommended for further evaluation. The pleural spaces are clear. The visualized musculoskeletal structures and the upper abdomen are stable and unremarkable.</content>
+  </paragraph>
+  ...
+
+
+</text>
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Text Observation -->
+    <templateId root="2.16.840.1.113883.10.20.6.2.12"/>
+    <code code="121071" codeSystem="1.2.840.10008.2.16.4" 
+          codeSystemName="DCM" displayName="Finding"/>
+    <value xsi:type="ED">
+      <reference value="#Fndng2"/>
+    </value>
+    ...
+    
+        
+    <!-- entryRelationships to SOP Instance Observations and Quantity 
+         Measurement Observations may go here -->
+  </observation>
+</entry>

--- a/Guide Examples/Tobacco Use (V2)_2.16.840.1.113883.10.20.22.4.85/README.md
+++ b/Guide Examples/Tobacco Use (V2)_2.16.840.1.113883.10.20.22.4.85/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Tobacco Use (V2)
+ 
+2.16.840.1.113883.10.20.22.4.85

--- a/Guide Examples/Tobacco Use (V2)_2.16.840.1.113883.10.20.22.4.85/Tobacco Use (V2) Example.xml
+++ b/Guide Examples/Tobacco Use (V2)_2.16.840.1.113883.10.20.22.4.85/Tobacco Use (V2) Example.xml
@@ -1,0 +1,20 @@
+<observation classCode="OBS" moodCode="EVN">
+  <!-- ** Tobacco use ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.85" extension="2014-06-09" />
+  <id root="45efb604-7049-4a2e-ad33-d38556c9636c" />
+  <code code="11367-0" codeSystem="2.16.840.1.113883.6.1" displayName="History of tobacco use" />
+  <statusCode code="completed" />
+  <effectiveTime>
+    <!-- The low value reflects the start date of the observation/value (moderate smoker) -->
+    <low value="20090214" />
+    <!-- The high value reflects the end date of the observation/value (moderate smoker) -->
+    <high value="20110215" />
+  </effectiveTime>
+  <value xsi:type="CD" code="160604004" displayName="Moderate cigarette smoker, 10-19/day" codeSystem="2.16.840.1.113883.6.96" />
+  <author typeCode="AUT">
+    <time value="201209101145-0800" />
+    <assignedAuthor>
+      <id extension="555555555" root="1.1.1.1.1.1.1.2" />
+    </assignedAuthor>
+  </author>
+</observation>

--- a/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/README.md
+++ b/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Transfer Summary (V2)
+ 
+2.16.840.1.113883.10.20.22.1.13

--- a/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary Callback Contact Example.xml
+++ b/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary Callback Contact Example.xml
@@ -1,0 +1,21 @@
+<participant typeCode="CALLBCK">
+  <time value="20050329224411+0500" />
+  <associatedEntity classCode="ASSIGNED">
+    <id extension="99999999" root="2.16.840.1.113883.4.6" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <addr>
+      <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:555-555-1002" />
+    <associatedPerson>
+      <name>
+        <given>Henry</given>
+        <family>Seven</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary participant (Support) Example.xml
+++ b/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary participant (Support) Example.xml
@@ -1,0 +1,49 @@
+<participant typeCode="IND">
+  <time xsi:type="IVL_TS">
+    <low value="19590101" />
+    <high value="20111025" />
+  </time>
+  <associatedEntity classCode="ECON">
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <addr>
+      <streetAddressLine>17 Daws Rd.</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(999)555-1212" use="WP" />
+    <associatedPerson>
+      <name>
+        <prefix>Mrs.</prefix>
+        <given>Martha</given>
+        <family>Jones</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>
+<participant typeCode="IND">
+  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  <time xsi:type="IVL_TS">
+    <low value="19590101" />
+    <high value="20111025" />
+  </time>
+  <associatedEntity classCode="CAREGIVER">
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <addr>
+      <streetAddressLine>17 Daws Rd.</streetAddressLine>
+      <city>Ann Arbor</city>
+      <state>MI</state>
+      <postalCode>97857</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(999)555-1212" use="WP" />
+    <associatedPerson>
+      <name>
+        <prefix>Mrs.</prefix>
+        <given>Martha</given>
+        <family>Jones</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/UDI Organizer_2.16.840.1.113883.10.20.22.4.311/README.md
+++ b/Guide Examples/UDI Organizer_2.16.840.1.113883.10.20.22.4.311/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+UDI Organizer
+ 
+2.16.840.1.113883.10.20.22.4.311

--- a/Guide Examples/UDI Organizer_2.16.840.1.113883.10.20.22.4.311/Unique Device Identifier (UDI) Organizer Example.xml
+++ b/Guide Examples/UDI Organizer_2.16.840.1.113883.10.20.22.4.311/Unique Device Identifier (UDI) Organizer Example.xml
@@ -1,0 +1,126 @@
+<!-- UDI Organizer -->
+<organizer classCode="CLUSTER" moodCode="EVN">
+	<templateId root="2.16.840.1.113883.10.20.22.4.312"          extension="2019-06-21"/>
+	<id assigningAuthorityName="FDA" extension="(01)4328998989(11)160330(10)ABC124"      root="GS1"/>
+	<code code="74711-3" codeSystem="2.16.840.1.113883.6.1"  displayName="Unique Device Identifier"/>
+	<statusCode code="completed"/>
+	<!-- UDI components -->
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.304"  extension="2019-06-21"/>
+			<code code="C101722" displayName="Primary DI Number"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<!-- GS1 Device Identifier -->
+			<value xsi:type="II" root="1.3.160"  extension="99994328998989" displayable="true"  assigningAuthorityName="GS1"/>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.315"  extension="2019-06-21"/>
+			<code code="C101672" displayName="Lot or Batch Number"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#LotOrBatchNumber_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.319"  extension="2019-06-21"/>
+			<code code="C101671" displayName="Serial Number"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#SerialNumber_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.316"  extension="2019-06-21"/>
+			<code code="C101669" displayName="Manufacturing Date"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="TS" value="20181015"/>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.309"  extension="2019-06-21"/>
+			<code code="C101670" displayName="Expiration Date"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="TS" value="20221015"/>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.308"  extension="2019-06-21"/>
+			<code code="C113843"  displayName="Distinct Identification Code"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#DistinctIdentificationCode_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.301"  extension="2019-06-21"/>
+			<code code="C71898" displayName="Brand Name"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#BrandName_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.317"  extension="2019-06-21"/>
+			<code code="C99285" displayName="Model Number"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#ModelNumber_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.302"  extension="2019-06-21"/>
+			<code code="C99286" displayName="Catalog Number"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#CatalogNumber_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.303"  extension="2019-06-21"/>
+			<code code="C54131" displayName="Company Name"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="ED">
+				<reference value="#CompanyName_1"/>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.318"  extension="2019-06-21"/>
+			<code code="C106044" displayName="MRI Safety Status"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="CD" code="C113844"  codeSystem="2.16.840.1.113883.3.26.1.1" displayName="Labeling does not contain MRI Safety Information"  codeSystemName="NCI Thesaurus" sdtc:valueSet="2.16.840.1.113762.1.4.1021.46">
+				<originalText>
+					<reference value="#MRISafety_1"/>
+				</originalText>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.314"  extension="2019-06-21"/>
+			<code code="C160938" displayName="Latex Safety Status"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="CD" code="C106038"  codeSystem="2.16.840.1.113883.3.26.1.1" displayName="Not Made with Natural Rubber Latex"  codeSystemName="NCI Thesaurus" sdtc:valueSet="2.16.840.1.113762.1.4.1021.47">
+				<originalText>
+					<reference value="#LatexSafety_1"/>
+				</originalText>
+			</value>
+		</observation>
+	</component>
+	<component>
+		<observation classCode="OBS" moodCode="EVN">
+			<templateId root="2.16.840.1.113883.10.20.22.4.305"  extension="2019-06-21"/>
+			<code code="C160939" displayName="Implantable Device Status"  codeSystem="2.16.840.1.113883.3.26.1.1"  codeSystemName="NCI Thesaurus"/>
+			<value xsi:type="CD" code="C160942"  codeSystem="2.16.840.1.113883.3.26.1.1" displayName="Reduced Function"  codeSystemName="NCI Thesaurus" sdtc:valueSet="2.16.840.1.113762.1.4.1021.48">
+				<originalText>
+					<reference value="#ImplantableDeviceStatus_1"/>
+				</originalText>
+			</value>
+		</observation>
+	</component>
+</organizer>

--- a/Guide Examples/US Realm Address (AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/README.md
+++ b/Guide Examples/US Realm Address (AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+US Realm Address (AD.US.FIELDED)
+ 
+2.16.840.1.113883.10.20.22.5.2

--- a/Guide Examples/US Realm Address (AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/US Realm Address Example.xml
+++ b/Guide Examples/US Realm Address (AD.US.FIELDED)_2.16.840.1.113883.10.20.22.5.2/US Realm Address Example.xml
@@ -1,0 +1,7 @@
+<addr use="HP">
+  <streetAddressLine>22 Sample Street</streetAddressLine>
+  <city>Beaverton</city>
+  <state>OR</state>
+  <postalCode>97867</postalCode>
+  <country>US</country>
+</addr>

--- a/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/README.md
+++ b/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+US Realm Date and Time (DTM.US.FIELDED)
+ 
+2.16.840.1.113883.10.20.22.5.4

--- a/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US Realm Date and Time Example.xml
+++ b/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US Realm Date and Time Example.xml
@@ -1,0 +1,8 @@
+<!-- Common values for date/time elements would range in precision to the day YYYYMMDD to precision to the second with a time zone offset YYYYMMDDHHMMSS - ZZzz -->
+<!-- time element with TS data type precise to the day for a birthdate -->
+<time value=�19800531�/>
+<!-- effectiveTime element with IVL<TS> data type precise to the second for an observation -->
+<effectiveTime>
+  <low value='20110706122735-0800'/>
+  <high value='20110706122815-0800'/>
+</effectiveTime>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Assigned Health Care Provider informant Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Assigned Health Care Provider informant Example.xml
@@ -1,0 +1,23 @@
+<informant>
+  <assignedEntity>
+    <id extension="888888888" root="1.1.1.1.1.1.1.3" />
+    <addr>
+      <streetAddressLine>1007 Healthcare Drive</streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1003" />
+    <assignedPerson>
+      <name>
+        <given>Harold</given>
+        <family>Hippocrates</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+      <name>The DoctorsApart Physician Group</name>
+    </representedOrganization>
+  </assignedEntity>
+</informant>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Digital signature Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Digital signature Example.xml
@@ -1,0 +1,4 @@
+<sdtc:signatureText mediaType="text/xml" representation="B64">omSJUEdmde9j44zmMiromSJUEdmde9j44zmMirdMDSsWdIJdksIJR3373jeu83
+			6edjzMMIjdMDSsWdIJdksIJR3373jeu83MNYD83jmMdomSJUEdmde9j44zmMir
+			... MNYD83jmMdomSJUEdmde9j44zmMir6edjzMMIjdMDSsWdIJdksIJR3373jeu83
+			4zmMir6edjzMMIjdMDSsWdIJdksIJR3373jeu83==</sdtc:signatureText>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Personal Relation informant Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Personal Relation informant Example.xml
@@ -1,0 +1,13 @@
+<informant>
+  <relatedEntity classCode="PRS">
+    <!-- classCode "PRS" represents a person with personal relationship with the patient -->
+    <code code="SPS" displayName="SPOUSE" codeSystem="2.16.840.1.113883.1.11.19563" codeSystemName="Personal Relationship Role Type Value Set" />
+    <relatedPerson>
+      <name>
+        <given>Boris</given>
+        <given qualifier="CL">Bo</given>
+        <family>Betterhalf</family>
+      </name>
+    </relatedPerson>
+  </relatedEntity>
+</informant>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/README.md
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+US Realm Header (V3)
+ 
+2.16.840.1.113883.10.20.22.1.1

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Supporting Person participant Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Supporting Person participant Example.xml
@@ -1,0 +1,42 @@
+<participant typeCode="IND">
+  <!-- typeCode "IND" represents an individual -->
+  <associatedEntity classCode="NOK">
+    <!-- classCode "NOK" represents the patient's next of kin-->
+    <addr use="HP">
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Beaverton</city>
+      <state>OR</state>
+      <postalCode>97867</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:+1(555)555-2008" use="MC" />
+    <associatedPerson>
+      <name>
+        <given>Boris</given>
+        <given qualifier="CL">Bo</given>
+        <family>Betterhalf</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>
+<!-- Entities playing multiple roles are recorded in multiple participants -->
+<participant typeCode="IND">
+  <associatedEntity classCode="ECON">
+    <!-- classCode "ECON" represents an emergency contact -->
+    <addr use="HP">
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Beaverton</city>
+      <state>OR</state>
+      <postalCode>97867</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:+1(555)555-2008" use="MC" />
+    <associatedPerson>
+      <name>
+        <given>Boris</given>
+        <given qualifier="CL">Bo</given>
+        <family>Betterhalf</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/US Realm Header (V3) Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/US Realm Header (V3) Example.xml
@@ -1,0 +1,20 @@
+<ClinicalDocument>
+  <realmCode code="US" />
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <!-- CCD template -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01" />
+  <!-- Globally unique identifier for the document  -->
+  <id extension="TT988" root="2.16.840.1.113883.19.5.99999.1" />
+  <code code="34133-9" displayName="Summarization of Episode Note" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+  <!-- Title of the document -->
+  <title>Patient Chart Summary</title>
+  <effectiveTime value="201209151030-0800" />
+  <confidentialityCode code="N" displayName="normal" codeSystem="2.16.840.1.113883.5.25" codeSystemName="Confidentiality" />
+  <languageCode code="en-US" />
+  <setId extension="sTT988" root="2.16.840.1.113883.19.5.99999.19" />
+  <!-- Version of the document -->
+  <versionNumber value="1" />
+     . . .
+
+
+</ClinicalDocument>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/authenticator Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/authenticator Example.xml
@@ -1,0 +1,24 @@
+<authenticator>
+  <time value="201209151030-0800" />
+  <signatureCode code="S" />
+  <assignedEntity>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.5.53" codeSystemName="Health Care Provider Taxonomy" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive</streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</authenticator>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/author Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/author Example.xml
@@ -1,0 +1,23 @@
+<author>
+  <time value="201209151030-0800" />
+  <assignedAuthor>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="163W00000X" displayName="Registered nurse" codeSystem="2.16.840.1.113883.5.53" codeSystemName="Health Care Provider Taxonomy" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/authorization Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/authorization Example.xml
@@ -1,0 +1,7 @@
+<authorization typeCode="AUTH">
+  <consent classCode="CONS" moodCode="EVN">
+    <id root="629deb70-5306-11df-9879-0800200c9a66" />
+    <code codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="64293-4" displayName="Procedure consent" />
+    <statusCode code="completed" />
+  </consent>
+</authorization>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/custodian Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/custodian Example.xml
@@ -1,0 +1,16 @@
+<custodian>
+  <assignedCustodian>
+    <representedCustodianOrganization>
+      <id extension="321CX" root="1.1.1.1.1.1.1.1.3" />
+      <name>Good Health HIE</name>
+      <telecom use="WP" value="tel:+1(555)555-1009" />
+      <addr use="WP">
+        <streetAddressLine>1009 Healthcare Drive </streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+    </representedCustodianOrganization>
+  </assignedCustodian>
+</custodian>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/dateEnterer Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/dateEnterer Example.xml
@@ -1,0 +1,19 @@
+<dataEnterer>
+  <assignedEntity>
+    <id extension="333777777" root="2.16.840.1.113883.4.6" />
+    <addr>
+      <streetAddressLine>1007 Healthcare Drive</streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1050" />
+    <assignedPerson>
+      <name>
+        <given>Ellen</given>
+        <family>Enter</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</dataEnterer>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/documentationOf Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/documentationOf Example.xml
@@ -1,0 +1,56 @@
+<documentationOf>
+  <serviceEvent classCode="PCPR">
+    <!-- The effectiveTime reflects the provision of care summarized in the document. 
+				In this scenario, the provision of care summarized is the lifetime for the patient -->
+    <effectiveTime>
+      <low value="19750501" />
+      <!-- The low value represents when the summarized provision of care began. 
+					In this scenario, the patient's date of birth -->
+      <high value="20120915" />
+      <!-- The high value represents when the summarized provision of care being ended. 
+					In this scenario, when chart summary was created -->
+    </effectiveTime>
+    <performer typeCode="PRF">
+      <functionCode code="PCP" 
+                displayName="Primary Care Provider"
+                codeSystem="2.16.840.1.113883.5.88"
+                codeSystemName="ParticipationFunction">
+        <originalText>Primary Care Provider</originalText>
+      </functionCode>
+      <assignedEntity>
+        <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+        <code code="207QA0505X" displayName="Adult Medicine" 
+                    codeSystem="2.16.840.1.113883.5.53" 
+                    codeSystemName="Health Care Provider Taxonomy" />
+        <addr>
+          <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+          <city>Portland</city>
+          <state>OR</state>
+          <postalCode>99123</postalCode>
+          <country>US</country>
+        </addr>
+        <telecom use="WP" value="tel:+1(555)555-1004" />
+        <assignedPerson>
+          <name>
+            <given>Patricia</given>
+            <given qualifier="CL">Patty</given>
+            <family>Primary</family>
+            <suffix qualifier="AC">M.D.</suffix>
+          </name>
+        </assignedPerson>
+        <representedOrganization>
+          <id extension="219BX" root="1.1.1.1.1.1.1.1.2" />
+          <name>The DoctorsTogether Physician Group</name>
+          <telecom use="WP" value="tel: +(555)-555-5000" />
+          <addr>
+            <streetAddressLine>1004 Health Drive</streetAddressLine>
+            <city>Portland</city>
+            <state>OR</state>
+            <postalCode>99123</postalCode>
+            <country>US</country>
+          </addr>
+        </representedOrganization>
+      </assignedEntity>
+    </performer>
+  </serviceEvent>
+</documentationOf>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/inFulfillmentOf Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/inFulfillmentOf Example.xml
@@ -1,0 +1,6 @@
+<inFulfillmentOf typeCode="FLFS">
+  <order classCode="ACT" moodCode="RQO">
+    <id root="2.16.840.1.113883.6.96" extension="1298989898" />
+    <code code="388975008" displayName="Weight Reduction Consultation" codeSystem="2.16.840.1.113883.6.96" codeSystemName="CPT4" />
+  </order>
+</inFulfillmentOf>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/informationRecipient Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/informationRecipient Example.xml
@@ -1,0 +1,14 @@
+<informationRecipient>
+  <intendedRecipient>
+    <informationRecipient>
+      <name>
+        <given>Sara</given>
+        <family>Specialize</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </informationRecipient>
+    <receivedOrganization>
+      <name>The DoctorsApart Physician Group</name>
+    </receivedOrganization>
+  </intendedRecipient>
+</informationRecipient>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/legalAuthenticator Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/legalAuthenticator Example.xml
@@ -1,0 +1,24 @@
+<legalAuthenticator>
+  <time value="20120915223615-0800" />
+  <signatureCode code="S" />
+  <assignedEntity>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.5.53" codeSystemName="Health Care Provider Taxonomy" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</legalAuthenticator>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/performer Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/performer Example.xml
@@ -1,0 +1,40 @@
+<performer typeCode="PRF">
+  <functionCode code="PCP" 
+              displayName="Primary Care Provider"
+              codeSystem="2.16.840.1.113883.5.88"
+              codeSystemName="ParticipationFunction">
+    <originalText>Primary Care Provider</originalText>
+  </functionCode>
+  <assignedEntity>
+    <id extension="5555555555" root="2.16.840.1.113883.4.6" />
+    <code code="207QA0505X" displayName="Adult Medicine" codeSystem="2.16.840.1.113883.5.53" codeSystemName="Health Care Provider Taxonomy" />
+    <addr>
+      <streetAddressLine>1004 Healthcare Drive </streetAddressLine>
+      <city>Portland</city>
+      <state>OR</state>
+      <postalCode>99123</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:+1(555)555-1004" />
+    <assignedPerson>
+      <name>
+        <given>Patricia</given>
+        <given qualifier="CL">Patty</given>
+        <family>Primary</family>
+        <suffix qualifier="AC">M.D.</suffix>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+      <id extension="219BX" root="1.1.1.1.1.1.1.1.2" />
+      <name>The DoctorsTogether Physician Group</name>
+      <telecom use="WP" value="tel: +(555)-555-5000" />
+      <addr>
+        <streetAddressLine>1004 Health Drive</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+    </representedOrganization>
+  </assignedEntity>
+</performer>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget Example.xml
@@ -1,0 +1,94 @@
+<recordTarget>
+  <patientRole>
+    <id extension="444-22-2222" root="2.16.840.1.113883.4.1" />
+    <!-- Example Social Security Number using the actual SSN OID. -->
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Beaverton</city>
+      <state>OR</state>
+      <postalCode>97867</postalCode>
+      <country>US</country>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+    </addr>
+    <telecom value="tel:+1(555)555-2003" use="HP" />
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <patient>
+      <!-- The first name element represents what the patient is known as -->
+      <name use="L">
+        <given>Eve</given>
+        <!-- The "SP" is "Spouse" from
+                     HL7 Code System EntityNamePartQualifier 2.16.840.1.113883.5.43 -->
+        <family qualifier="SP">Betterhalf</family>
+      </name>
+      <!-- The second name element represents another name 
+                 associated with the patient -->
+      <name>
+        <given>Eve</given>
+        <!-- The "BR" is "Birth" from 
+                     HL7 Code System EntityNamePartQualifier 2.16.840.1.113883.5.43 -->
+        <family qualifier="BR">Everywoman</family>
+      </name>
+      <administrativeGenderCode code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" />
+      <!-- Date of birth need only be precise to the day -->
+      <birthTime value="19750501" />
+      <maritalStatusCode code="M" displayName="Married" codeSystem="2.16.840.1.113883.5.2" codeSystemName="MaritalStatusCode" />
+      <religiousAffiliationCode code="1013" displayName="Christian (non-Catholic, non-specific)" codeSystem="2.16.840.1.113883.5.1076" codeSystemName="HL7 Religious Affiliation" />
+      <!-- CDC Race and Ethnicity code set contains the five minimum
+                 race and ethnicity categories defined by OMB Standards -->
+      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <!-- The raceCode extension is only used if raceCode is valued -->
+      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <guardian>
+        <code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty" />
+        <addr use="HP">
+          <streetAddressLine>2222 Home Street</streetAddressLine>
+          <city>Beaverton</city>
+          <state>OR</state>
+          <postalCode>97867</postalCode>
+          <country>US</country>
+        </addr>
+        <telecom value="tel:+1(555)555-2008" use="MC" />
+        <guardianPerson>
+          <name>
+            <given>Boris</given>
+            <given qualifier="CL">Bo</given>
+            <family>Betterhalf</family>
+          </name>
+        </guardianPerson>
+      </guardian>
+      <birthplace>
+        <place>
+          <addr>
+            <streetAddressLine>4444 Home Street</streetAddressLine>
+            <city>Beaverton</city>
+            <state>OR</state>
+            <postalCode>97867</postalCode>
+            <country>US</country>
+          </addr>
+        </place>
+      </birthplace>
+      <languageCommunication>
+        <languageCode code="eng" />
+        <!-- "eng" is ISO 639-2 alpha-3 code for "English" -->
+        <modeCode code="ESP" displayName="Expressed spoken" codeSystem="2.16.840.1.113883.5.60" codeSystemName="LanguageAbilityMode" />
+        <proficiencyLevelCode code="G" displayName="Good" codeSystem="2.16.840.1.113883.5.61" codeSystemName="LanguageAbilityProficiency" />
+        <!-- Patient's preferred language -->
+        <preferenceInd value="true" />
+      </languageCommunication>
+    </patient>
+    <providerOrganization>
+      <id extension="219BX" root="1.1.1.1.1.1.1.1.2" />
+      <name>The DoctorsTogether Physician Group</name>
+      <telecom use="WP" value="tel: +(555)-555-5000" />
+      <addr>
+        <streetAddressLine>1007 Health Drive</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+    </providerOrganization>
+  </patientRole>
+</recordTarget>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document authenticator Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document authenticator Example.xml
@@ -1,0 +1,26 @@
+<authenticator>
+  <time value="20121126145000-0500" />
+  <signatureCode code="S" />
+  <assignedEntity>
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</authenticator>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document author Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document author Example.xml
@@ -1,0 +1,30 @@
+<author>
+  <time value="20121126145000-0500" />
+  <assignedAuthor>
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+    <!-- 
+				The PGD Header Template includes further conformance constraints on the code element to encode the personal or legal 
+				relationship of the author when they are person who is not acting in the role of a clinician.. 
+			-->
+    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document author device Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document author device Example.xml
@@ -1,0 +1,28 @@
+<!-- The Author below documents the system used to create the Patient Generated Document.
+		In this scenario the Patient is using a fictitious PHR Service called MyPersonalHealthRecord.com. 
+		It is a service which consumers purchase to receive and create their electronic health records. 
+		It is not a Patient Portal that is tethered to some other EMR or medical insurance records system.
+		The service is developed by a company call ACME PHR Solutions, Inc. -->
+<author>
+  <time value="20121126145000-0500" />
+  <assignedAuthor>
+    <id extension="777.11" root="2.16.840.1.113883.19" />
+    <addr nullFlavor="NA" />
+    <telecom nullFlavor="NA" />
+    <assignedAuthoringDevice>
+      <manufacturerModelName>ACME PHR</manufacturerModelName>
+      <softwareName>MyPHR v1.0</softwareName>
+    </assignedAuthoringDevice>
+    <representedOrganization>
+      <id extension="999" root="1.2.3.4.5.6.7.8.9.12345" />
+      <name>ACME PHR Solutions, Inc.</name>
+      <telecom use="WP" value="tel:123-123-12345" />
+      <addr>
+        <streetAddressLine>4 Future Way</streetAddressLine>
+        <city>Provenance</city>
+        <state>RI</state>
+        <postalCode>02919</postalCode>
+      </addr>
+    </representedOrganization>
+  </assignedAuthor>
+</author>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document custodian Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document custodian Example.xml
@@ -1,0 +1,17 @@
+<custodian>
+  <assignedCustodian>
+    <representedCustodianOrganization>
+      <!-- id using HL7 example OID. -->
+      <id extension="999.3" root="2.16.840.1.113883.19" />
+      <name>MyPersonalHealthRecord.Com</name>
+      <telecom value="tel:(555)555-1212" use="WP" />
+      <addr use="WP">
+        <streetAddressLine>123 Boylston Street</streetAddressLine>
+        <city>Blue Hill</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>USA</country>
+      </addr>
+    </representedCustodianOrganization>
+  </assignedCustodian>
+</custodian>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document dataEnterer Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document dataEnterer Example.xml
@@ -1,0 +1,25 @@
+<dataEnterer>
+  <assignedEntity>
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</dataEnterer>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document inFulfillmentOf Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document inFulfillmentOf Example.xml
@@ -1,0 +1,6 @@
+<inFulfillmentOf>
+  <order>
+    <!-- The root identifies the EMR system at the Good Health Internal Medicine Practice -->
+    <id extension="Ord12345" root="2.16.840.1.113883.4.6.1234567890.4" />
+  </order>
+</inFulfillmentOf>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informant Example informant.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informant Example informant.xml
@@ -1,0 +1,24 @@
+<informant>
+  <assignedEntity>
+    <!-- id using HL7 example OID. -->
+    <id extension="999.1" root="2.16.840.1.113883.19" />
+    <code code="ONESELF" displayName="Self" codeSystem="2.16.840.1.113883.5.111" codeSystemName="HL7 Role code" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</informant> 

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informant RelEnt Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informant RelEnt Example.xml
@@ -1,0 +1,25 @@
+<informant>
+  <!-- An Errata has been accepted to allow relatedEntity under Informant. #XXXX -->
+  <relatedEntity classCode="IND">
+    <!-- id using HL7 example OID. -->
+    <id extension="999.17" root="2.16.840.1.113883.19" />
+    <code code="SIS" displayName="Sister" codeSystem="2.16.840.1.113883.11.20.12.1" codeSystemName="Personal And Legal Relationship Role Type" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Alice</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </relatedEntity>
+</informant>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informationRecipient.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informationRecipient.xml
@@ -1,0 +1,55 @@
+<!-- The document is intended for multiple recipients, Adam himself and his PCP physician. -->
+<informationRecipient>
+  <intendedRecipient>
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+    <informationRecipient>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </informationRecipient>
+    <receivedOrganization>
+      <!-- id using HL7 example OID. -->
+      <id extension="999.3" root="2.16.840.1.113883.19" />
+      <name>MyPersonalHealthRecord.Com</name>
+    </receivedOrganization>
+  </intendedRecipient>
+</informationRecipient>
+<informationRecipient>
+  <intendedRecipient>
+    <!-- Unique/Trusted id using HL7 example OID. -->
+    <id extension="999.4" root="2.16.840.1.113883.19" />
+    <!-- The physician's NPI number -->
+    <id extension="1122334455" root="2.16.840.1.113883.4.6" />
+    <!-- The physician's Direct Address -->
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="DrP@direct.sampleHISP2.com" root="2.16.123.123.12345.4321" />
+    <telecom use="WP" value="tel:(781)555-1212" />
+    <telecom use="WP" value="mailto:DrP@direct.sampleHISP2.com" />
+    <informationRecipient>
+      <name>
+        <prefix>Dr.</prefix>
+        <given>Patricia</given>
+        <family>Primary</family>
+      </name>
+    </informationRecipient>
+    <receivedOrganization>
+      <!-- Unique/Trusted id using HL7 example OID. -->
+      <id extension="999.2" root="2.16.840.1.113883.19" />
+      <!-- NPI for the organization -->
+      <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+      <name>Good Health Internal Medicine</name>
+      <telecom use="WP" value="tel:(781)555-1212" />
+      <addr>
+        <streetAddressLine>100 Health Drive</streetAddressLine>
+        <city>Boston</city>
+        <state>MA</state>
+        <postalCode>02368</postalCode>
+        <country>USA</country>
+      </addr>
+    </receivedOrganization>
+  </intendedRecipient>
+</informationRecipient>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document legalAuthenticator Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document legalAuthenticator Example.xml
@@ -1,0 +1,26 @@
+<legalAuthenticator>
+  <time value="20121126145000-0500" />
+  <signatureCode code="S" />
+  <assignedEntity>
+    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Boston</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+      <country>US</country>
+    </addr>
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <telecom value="tel:(555)555-2004" use="HP" />
+    <assignedPerson>
+      <name>
+        <given>Adam</given>
+        <family>Everyman</family>
+      </name>
+    </assignedPerson>
+  </assignedEntity>
+</legalAuthenticator>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document participant Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document participant Example.xml
@@ -1,0 +1,24 @@
+<participant typeCode="IND">
+  <time xsi:type="IVL_TS">
+    <low value="19551125" />
+    <high value="20121126" />
+  </time>
+  <associatedEntity classCode="NOK">
+    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+    <addr>
+      <streetAddressLine>17 Daws Rd.</streetAddressLine>
+      <city>Blue Bell</city>
+      <state>MA</state>
+      <postalCode>02368</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom value="tel:(555)555-2006" use="WP" />
+    <associatedPerson>
+      <name>
+        <prefix>Mrs.</prefix>
+        <given>Martha</given>
+        <family>Mum</family>
+      </name>
+    </associatedPerson>
+  </associatedEntity>
+</participant>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document recordTarget Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document recordTarget Example.xml
@@ -1,0 +1,95 @@
+<recordTarget>
+  <patientRole>
+    <id extension="444-22-2222" root="2.16.840.1.113883.4.1" />
+    <!-- Example Social Security Number using the actual SSN OID. -->
+    <addr use="HP">
+      <!-- HP is "primary home" from codeSystem 2.16.840.1.113883.5.1119 -->
+      <streetAddressLine>2222 Home Street</streetAddressLine>
+      <city>Beaverton</city>
+      <state>OR</state>
+      <postalCode>97867</postalCode>
+      <country>US</country>
+      <!-- US is "United States" from ISO 3166-1 Country Codes: 1.0.3166.1 -->
+    </addr>
+    <telecom value="tel:+1(555)555-2003" use="HP" />
+    <!-- HP is "primary home" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
+    <patient>
+      <!-- The first name element represents what the patient is known as -->
+      <name use="L">
+        <given>Eve</given>
+        <!-- The "SP" is "Spouse" from
+                     HL7 Code System EntityNamePartQualifier 2.16.840.1.113883.5.43 -->
+        <family qualifier="SP">Betterhalf</family>
+      </name>
+      <!-- The second name element represents another name 
+                 associated with the patient -->
+      <name>
+        <given>Eve</given>
+        <!-- The "BR" is "Birth" from 
+                     HL7 Code System EntityNamePartQualifier 2.16.840.1.113883.5.43 -->
+        <family qualifier="BR">Everywoman</family>
+      </name>
+      <administrativeGenderCode code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender" />
+      <!-- Date of birth need only be precise to the day -->
+      <birthTime value="19750501" />
+      <maritalStatusCode code="M" displayName="Married" codeSystem="2.16.840.1.113883.5.2" codeSystemName="MaritalStatusCode" />
+      <religiousAffiliationCode code="1013" displayName="Christian (non-Catholic, non-specific)" codeSystem="2.16.840.1.113883.5.1076" codeSystemName="HL7 Religious Affiliation" />
+      <!-- CDC Race and Ethnicity code set contains the five minimum
+                 race and ethnicity categories defined by OMB Standards -->
+      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <!-- The raceCode extension is only used if raceCode is valued -->
+      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <guardian>
+        <id root="2.16.840.1.113883.4.1" extension="111-22-3333" />
+        <code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty" />
+        <addr use="HP">
+          <streetAddressLine>2222 Home Street</streetAddressLine>
+          <city>Beaverton</city>
+          <state>OR</state>
+          <postalCode>97867</postalCode>
+          <country>US</country>
+        </addr>
+        <telecom value="tel:+1(555)555-2008" use="MC" />
+        <guardianPerson>
+          <name>
+            <given>Boris</given>
+            <given qualifier="CL">Bo</given>
+            <family>Betterhalf</family>
+          </name>
+        </guardianPerson>
+      </guardian>
+      <birthplace>
+        <place>
+          <addr>
+            <streetAddressLine>4444 Home Street</streetAddressLine>
+            <city>Beaverton</city>
+            <state>OR</state>
+            <postalCode>97867</postalCode>
+            <country>US</country>
+          </addr>
+        </place>
+      </birthplace>
+      <languageCommunication>
+        <languageCode code="eng" />
+        <!-- "eng" is ISO 639-2 alpha-3 code for "English" -->
+        <modeCode code="ESP" displayName="Expressed spoken" codeSystem="2.16.840.1.113883.5.60" codeSystemName="LanguageAbilityMode" />
+        <proficiencyLevelCode code="G" displayName="Good" codeSystem="2.16.840.1.113883.5.61" codeSystemName="LanguageAbilityProficiency" />
+        <!-- Patient's preferred language -->
+        <preferenceInd value="true" />
+      </languageCommunication>
+    </patient>
+    <providerOrganization>
+      <id extension="219BX" root="1.1.1.1.1.1.1.1.2" />
+      <name>The DoctorsTogether Physician Group</name>
+      <telecom use="WP" value="tel: +(555)-555-5000" />
+      <addr>
+        <streetAddressLine>1007 Health Drive</streetAddressLine>
+        <city>Portland</city>
+        <state>OR</state>
+        <postalCode>99123</postalCode>
+        <country>US</country>
+      </addr>
+    </providerOrganization>
+  </patientRole>
+</recordTarget>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/README.md
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+US Realm Header for Patient Generated Document (V2)
+ 
+2.16.840.1.113883.10.20.29.1

--- a/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/README.md
+++ b/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+US Realm Patient Name (PTN.US.FIELDED)
+ 
+2.16.840.1.113883.10.20.22.5.1

--- a/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US Realm Patient Name Example.xml
+++ b/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US Realm Patient Name Example.xml
@@ -1,0 +1,8 @@
+<name use="L">
+  <prefix qualifier="TITLE">Rep
+  </suffix>
+  <given>Evelyn</given>
+  <given qualifier="CL">Eve</given>
+  <family qualifier="BR">Everywoman</family>
+  <suffix qualifier="AC">J.D.</suffix>
+</name>

--- a/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/README.md
+++ b/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Unstructured Document (V3)
+ 
+2.16.840.1.113883.10.20.22.1.10

--- a/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Compressed Content.xml
+++ b/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Compressed Content.xml
@@ -1,0 +1,5 @@
+<component>
+  <nonXMLBody>
+    <text mediaType="text/rtf" representation="B64" compression="DF">dhUhkasd437hbjfQS7�</text>
+  </nonXMLBody>
+</component>

--- a/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Embedded Content.xml
+++ b/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Embedded Content.xml
@@ -1,0 +1,5 @@
+<component>
+  <nonXMLBody>
+    <text mediaType="text/rtf" representation="B64">e1xydGY...</text>
+  </nonXMLBody>
+</component>

--- a/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Referenced Content.xml
+++ b/Guide Examples/Unstructured Document (V3)_2.16.840.1.113883.10.20.22.1.10/nonXMLBody Example with Referenced Content.xml
@@ -1,0 +1,7 @@
+<component>
+  <nonXMLBody>
+    <text>
+      <reference value="UD_sample.pdf" />
+    </text>
+  </nonXMLBody>
+</component>

--- a/Guide Examples/Vital Sign Observation (V2)_2.16.840.1.113883.10.20.22.4.27/README.md
+++ b/Guide Examples/Vital Sign Observation (V2)_2.16.840.1.113883.10.20.22.4.27/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Vital Sign Observation (V2)
+ 
+2.16.840.1.113883.10.20.22.4.27

--- a/Guide Examples/Vital Sign Observation (V2)_2.16.840.1.113883.10.20.22.4.27/Vital Sign Observation (V2) Example.xml
+++ b/Guide Examples/Vital Sign Observation (V2)_2.16.840.1.113883.10.20.22.4.27/Vital Sign Observation (V2) Example.xml
@@ -1,0 +1,12 @@
+<observation classCode="OBS" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+  <!-- Vital Sign Observation template -->
+  <id root="c6f88321-67ad-11db-bd13-0800200c9a66" />
+  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Height" />
+  <statusCode code="completed" />
+  <effectiveTime value="20121114" />
+  <value xsi:type="PQ" value="177" unit="cm" />
+    ....
+
+
+</observation>

--- a/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/README.md
+++ b/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Vital Signs Organizer (V3)
+ 
+2.16.840.1.113883.10.20.22.4.26

--- a/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/Vital Signs Organizer (V3) Example.xml
+++ b/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/Vital Signs Organizer (V3) Example.xml
@@ -1,0 +1,44 @@
+<organizer classCode="CLUSTER" moodCode="EVN">
+  <!-- ** Vital signs organizer ** -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.26" extension="2015-08-01" />
+  <id root="24f6ad18-c512-40fc-82bd-1e131aa9e52b" />
+  <code code="46680005" displayName="Vital Signs" 
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+    <translation code="74728-7" 
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel "
+                                    codeSystem="2.16.840.1.113883.6.1"
+                                    codeSystemName="LOINC"></translation>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="20120910" />
+    <high value="20120910" />
+  </effectiveTime>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+      <!-- Vital Sign Observation template -->
+            ...
+        
+        
+    </observation>
+  </component>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+      <!-- Vital Sign Observation template -->
+            ...
+        
+        
+    </observation>
+  </component>
+  <component>
+    <observation classCode="OBS" moodCode="EVN">
+      <templateId root="2.16.840.1.113883.10.20.22.4.27" extension="2014-06-09" />
+      <!-- Vital Sign Observation template -->
+            ...
+        
+        
+    </observation>
+  </component>
+</organizer>

--- a/Guide Examples/Vital Signs Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.4.1/README.md
+++ b/Guide Examples/Vital Signs Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.4.1/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Vital Signs Section (entries required) (V3)
+ 
+2.16.840.1.113883.10.20.22.2.4.1

--- a/Guide Examples/Vital Signs Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.4.1/Vital Signs Section (entries required) (V3) Example.xml
+++ b/Guide Examples/Vital Signs Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.4.1/Vital Signs Section (entries required) (V3) Example.xml
@@ -1,0 +1,20 @@
+<component>
+  <section>
+    <!-- ** Vital Signs section with entries required ** -->
+    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+    <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="VITAL SIGNS" />
+    <title>VITAL SIGNS</title>
+    <text>
+        . . .
+        </text>
+    <entry typeCode="DRIV">
+      <organizer classCode="CLUSTER" moodCode="EVN">
+        <!-- ** Vital signs organizer ** -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.26" extension="2015-08-01" />
+                . . .
+            
+            
+      </organizer>
+    </entry>
+  </section>
+</component>

--- a/Guide Examples/Wound Characteristic_2.16.840.1.113883.10.20.22.4.134/README.md
+++ b/Guide Examples/Wound Characteristic_2.16.840.1.113883.10.20.22.4.134/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Wound Characteristic
+ 
+2.16.840.1.113883.10.20.22.4.134

--- a/Guide Examples/Wound Characteristic_2.16.840.1.113883.10.20.22.4.134/Wound Characteristic Example.xml
+++ b/Guide Examples/Wound Characteristic_2.16.840.1.113883.10.20.22.4.134/Wound Characteristic Example.xml
@@ -1,0 +1,11 @@
+<entryRelationship typeCode="COMP">
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Wound Characteristic -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.134" />
+    <id root="763428a0-eb35-11e2-91e2-0700200c9a66" />
+    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+    <statusCode code="completed" />
+    <effectiveTime value="20013103" />
+    <value xsi:type="CD" code="447547000" displayName="Offensive wound odor" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+  </observation>
+</entryRelationship>

--- a/Guide Examples/Wound Measurement Observation_2.16.840.1.113883.10.20.22.4.133/README.md
+++ b/Guide Examples/Wound Measurement Observation_2.16.840.1.113883.10.20.22.4.133/README.md
@@ -1,0 +1,11 @@
+## SDWG Supported Sample from Implementation Guide
+
+The initial load of this repository in Januuary 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 
+
+These examples were reviewed through the HL7 ballot process. They have not been formally reviewed/approved by the examples task force.
+
+### Keywords:
+
+Wound Measurement Observation
+ 
+2.16.840.1.113883.10.20.22.4.133

--- a/Guide Examples/Wound Measurement Observation_2.16.840.1.113883.10.20.22.4.133/Wound Measurement Observation Example.xml
+++ b/Guide Examples/Wound Measurement Observation_2.16.840.1.113883.10.20.22.4.133/Wound Measurement Observation Example.xml
@@ -1,0 +1,11 @@
+<entryRelationship typeCode="COMP">
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- Wound Measurements Observation . -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.133" />
+    <id root="d2b46280-eb34-11e2-91e2-0800200c9a66" />
+    <code code=" 401238003" codeSystem="2.16.840.1.113883.6.96" displayName="Length of Wound" />
+    <statusCode code="completed" />
+    <effectiveTime value="20013103" />
+    <value xsi:type="PQ" value="2" unit="[in_i]" />
+  </observation>
+</entryRelationship>


### PR DESCRIPTION
This adds all the examples for 215 templates from the C-CDA 2.1 IG and the Companion Guide appendices. 

While these will not be reviewed/approved by the example task force, having them online in a github repository will make them more accessible and usable to implementation community. 