### PR TITLE
Adding link to approved Google document for participation in CDA 

### DIFF
--- a/General/Authors Performers Informants Participants in CDA Documents/Authors Performers Informants Participants in CDA Documents.url
+++ b/General/Authors Performers Informants Participants in CDA Documents/Authors Performers Informants Participants in CDA Documents.url
@@ -1,0 +1,5 @@
+[{000214A0-0000-0000-C000-000000000046}]
+Prop3=19,11
+[InternetShortcut]
+IDList=
+URL=https://docs.google.com/document/d/1RpZyOTgIjGabMvNHiwKqn7yY0VTzB0LAlAqhbuU92Iw/edit

--- a/General/Authors Performers Informants Participants in CDA Documents/Readme.md
+++ b/General/Authors Performers Informants Participants in CDA Documents/Readme.md
@@ -2,7 +2,7 @@
 
 * Approval Status: Approved
 * Example Task Force: 4/15/2021
-* SDWG: Pending
+* SDWG: 5/6/2021 Approved
 
 ### C-CDA 2.1 Example:
 

--- a/General/Authors Performers Informants Participants in CDA Documents/Readme.md
+++ b/General/Authors Performers Informants Participants in CDA Documents/Readme.md
@@ -1,0 +1,32 @@
+## Approval Status 
+
+* Approval Status: Approved
+* Example Task Force: 4/15/2021
+* SDWG: Pending
+
+### C-CDA 2.1 Example:
+
+* N/A
+
+### Reference to full CDA sample:
+
+* N/A
+
+### Validation location
+
+* N/A
+
+### Comments
+* This is a reference to a google document summarizing guidance for [Authors, Performers, Informants and Participants in CDA Documents](https://docs.google.com/document/d/1RpZyOTgIjGabMvNHiwKqn7yY0VTzB0LAlAqhbuU92Iw/edit). This guidance stems from work done as part of the [C-CDA Implement-a-thon in October 2020](https://confluence.hl7.org/display/IAT/2020.10.21+Virtual+IAT+Track+Agenda). 
+
+### Custodian
+
+* John D'Amore, johnd@moreinformatics.com (GitHub: jddamore)
+
+### Keywords
+
+* author, performer, informant, participant, participation, data provenance 
+
+### Permalink
+
+* TBD


### PR DESCRIPTION
documents. 

This was approved by task force at 4/15/2021 meeting. There will be an accompanying example for medications when approved (TBD)