### PR TITLE
Remove slashes from mailto URIs

### DIFF
--- a/Documents/CCD/CCD 2/CCD.xml
+++ b/Documents/CCD/CCD 2/CCD.xml
@@ -61,7 +61,7 @@
 			<!-- MC is "mobile contact" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
 			<telecom value="tel:+1(444)444-4444" use="MC"/>
 			<!-- Multiple telecoms are possible -->
-			<telecom value="mailto://Isbella.Jones.CCD@gmail.com"/>
+			<telecom value="mailto:Isbella.Jones.CCD@gmail.com"/>
 			<patient>
 				<name use="L">
 					<given>Isabella</given>

--- a/Header/Patient Demographic Information/Patient Demographic Information(C-CDA2.1).xml
+++ b/Header/Patient Demographic Information/Patient Demographic Information(C-CDA2.1).xml
@@ -21,7 +21,7 @@
         <!-- MC is "mobile contact" from HL7 AddressUse 2.16.840.1.113883.5.1119 -->
         <telecom value="tel:+1(565)867-5309" use="MC"/>
         <!-- Multiple telecoms are possible -->
-        <telecom value="mailto://adam@diameterhealth.com" use="WP"/>
+        <telecom value="mailto:adam@diameterhealth.com" use="WP"/>
         <patient>
             <name use="L">
                 <given>Adam</given>

--- a/Header/Patient With Prior Addresses/Patient With Prior Addresses(C-CDAR2.1).xml
+++ b/Header/Patient With Prior Addresses/Patient With Prior Addresses(C-CDAR2.1).xml
@@ -41,7 +41,7 @@
             </useablePeriod>
         </addr>
         <telecom value="tel:+1(565)867-5309" use="MC"/>
-        <telecom value="mailto://adam@diameterhealth.com" use="WP"/>
+        <telecom value="mailto:adam@diameterhealth.com" use="WP"/>
         <patient>
             <name use="L">
                 <given>Adam</given>


### PR DESCRIPTION
Noticed something really minor this morning--per [RFC 6068](https://www.rfc-editor.org/rfc/rfc6068), `mailto` URIs should just look like `mailto:infobot@example.com` rather than `mailto://infobot@example.com`. We had a couple examples floating around with slashes resulting in invalid `mailto` URIs.