### PR TITLE
Tweaked a few examples to ensure XML validity.

### DIFF
--- a/Encounters/Hospital Discharge Encounter with Billable Diagnoses/Hospital Discharge Encounter with Billable Diagnoses(C-CDA2.1).xml
+++ b/Encounters/Hospital Discharge Encounter with Billable Diagnoses/Hospital Discharge Encounter with Billable Diagnoses(C-CDA2.1).xml
@@ -133,7 +133,7 @@
 								<!-- This represents the date of biological onset. Since this is a coded diagnosis, this may not be documented.-->
 								<low nullFlavor="UNK" />
 							</effectiveTime>
-							<!-- QRDA R5.2  -- Updated to use Rank Observation to indicate  Principal Diagnosis. There is generally only a single diagnosis for coded bill.-->
+							<!-- QRDA R5.2: Updated to use Rank Observation to indicate  Principal Diagnosis. There is generally only a single diagnosis for coded bill.-->
 							<!-- priorityCode is No longer recommended to indicate principal diagnosis -->
 							<!--  <priorityCode code="63161005" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Principal"/> -->
 							<!-- This is a hospital discharge diagnosis, so the ICD-9 (or ICD-10) diagnosis is in translation. -->
@@ -201,7 +201,7 @@
 								<!-- This represents the date of biological onset. Since this is a coded diagnosis, this may not be documented.-->
 								<low nullFlavor="UNK" />
 							</effectiveTime>
-							<!-- QRDA R5.2  -- Updated to use Rank Observation to indicate Secondary Diagnosis. priorityCode is No longer recommended. -->
+							<!-- QRDA R5.2: Updated to use Rank Observation to indicate Secondary Diagnosis. priorityCode is No longer recommended. -->
 							<!-- <priorityCode code="2603003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Secondary"/> -->
 							<!-- This is a hospital discharge diagnosis, so the ICD-9 (or ICD-10) diagnosis is in translation. -->
 							<!-- If a SNOMED is available for this, it could be included, but mapping back from ICD-9 may not always be possible. -->

--- a/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/Assessment Scale Observation Example.xml
+++ b/Guide Examples/Assessment Scale Observation_2.16.840.1.113883.10.20.22.4.69/Assessment Scale Observation Example.xml
@@ -1,5 +1,4 @@
-   
-<observation classCode="OBS" moodCode="EVN">
+ <observation classCode="OBS" moodCode="EVN">
   <templateId root="2.16.840.1.113883.10.20.22.4.69"/>
   <id root="c6b5a04b-2bf4-49d1-8336-636a3813df0b"/>
   <code code="54614-3" 
@@ -15,9 +14,8 @@
     <observation classCode="OBS" moodCode="EVN">
       <templateId root="2.16.840.1.113883.10.20.22.4.86"/>
             
-            . . .
+      <!-- . . . -->
 
-    
-        
-    </entryRelationship>
-  </observation>
+    </observation>
+  </entryRelationship>
+</observation>

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note Callback participant Example.xml
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note Callback participant Example.xml
@@ -2,7 +2,7 @@
   <time value="20050329224411+0500" />
   <associatedEntity classCode="ASSIGNED">
     <id extension="99999999" root="2.16.840.1.113883.4.6" />
-    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic &amp; Osteopathic Physicians" />
     <addr>
       <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
       <city>Ann Arbor</city>

--- a/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note structuredBody Example.xml
+++ b/Guide Examples/Consultation Note (V3)_2.16.840.1.113883.10.20.22.1.4/Consultation Note structuredBody Example.xml
@@ -69,7 +69,7 @@
     <component>
       <section>
         <templateId root="2.16.840.1.113883.10.20.22.2.10" 
-                    extension="2014-06-09"" />
+                    extension="2014-06-09" />
         <!--  Plan of Treatment Section (V2) template  -->
         <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" 
                       codeSystemName="LOINC" displayName="Treatment plan" />

--- a/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis Reference Example.xml
+++ b/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Diagnosis Reference Example.xml
@@ -1,28 +1,53 @@
 <!-- Show how an encounter can include a discharge diagnosis which references an 
        item on the problem list using the Entry Reference template -->
-<!-- Problem Section -->
-<observation>
-  <id root="1234567" />
-  <code code="123" codeSystem="1.2.3" displayName="asthma" />
-</observation>
-<!-- Encounter Section -->
-<encounter>
-  <entryRelationship typeCode="COMP">
-    <act>
-      <code code="145" codeSystem="4.5.6" displayName="discharge diagnosis" />
-      <templateId root="2.16.840.1.113883.10.20.22.4.33" extension="2014-06-09" />
-      <!-- this is for illustrative purposes only. In this particular 
-                  case, the template requires a nested Problem 
-                  Observation (V2). In the Health Concern template, 
-                  we'd need a constraint that says it's allowable to 
-                  include the Entry Reference template. -->
-      <entryRelationship typeCode="SUBJ">
-        <act classCode="ACT" moodCode="XXX">
-          <templateId root="2.16.840.1.113883.10.20.22.4.122" />
-          <id root="1234567" />
-          <code nullFlavor="NP" />
-        </act>
-      </entryRelationship>
-    </act>
-  </entryRelationship>
-</encounter>
+<ClinicalDocument>
+  <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+       to demonstrate the locations of the entries across multiple different sections;
+       however, required content like the document header and section LOINC codes
+       has been omitted. -->
+  <component>
+    <structuredBody>
+      <component>
+        <!-- Problem Section -->
+        <section>
+          <!-- ... -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <id root="1234567" />
+              <code code="123" codeSystem="1.2.3" displayName="asthma" />
+            </observation>
+          </entry>
+        </section>
+      </component>
+      <!-- ... -->
+      <component>
+        <!-- Encounter Section -->
+        <section>
+          <entry>
+            <encounter classCode="ENC" moodCode="EVN">
+              <!-- ... -->
+              <entryRelationship typeCode="COMP">
+                <act>
+                  <code code="145" codeSystem="4.5.6" displayName="discharge diagnosis" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.33" extension="2014-06-09" />
+                  <!-- this is for illustrative purposes only. In this particular 
+                      case, the template requires a nested Problem 
+                      Observation (V2). In the Health Concern template, 
+                      we'd need a constraint that says it's allowable to 
+                      include the Entry Reference template. -->
+                  <entryRelationship typeCode="SUBJ">
+                    <act classCode="ACT" moodCode="XXX">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                      <id root="1234567" />
+                      <code nullFlavor="NP" />
+                    </act>
+                  </entryRelationship>
+                </act>
+              </entryRelationship>
+            </encounter>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Entry Reference Example.xml
+++ b/Guide Examples/Entry Reference_2.16.840.1.113883.10.20.22.4.122/Entry Reference Example.xml
@@ -1,81 +1,89 @@
-<!-- 
-  ********************************************************
-  Health Concern section
-  ********************************************************
--->
-<act classCode="ACT" moodCode="EVN">
-  <!-- Health Concern Act of a pneumonia diagnosis -->
-  <templateId root="2.16.840.1.113883.10.20.22.4.132" />
-  <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
-  <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern" />
-  <statusCode code="active" />
-  <effectiveTime value="20130616" />
-  <entryRelationship typeCode="REFR">
-    <!-- Problem Observation (V2) -->
-    <observation classCode="OBS" moodCode="EVN">
-      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2014-06-09" />
-      <id root="8dfacd73-1682-4cc4-9351-e54ccea83612" />
-      <code code="29308-4" 
-            codeSystem="2.16.840.1.113883.6.1" 
-            codeSystemName="LOINC" 
-            displayName="Diagnosis"/>
-      <statusCode code="completed" />
-      <effectiveTime>
-        <!-- Date of diagnosis -->
-        <low value="20130616" />
-      </effectiveTime>
-      <value xsi:type="CD" code="233604007" 
-            codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED" 
-            displayName="Pneumonia" />
-      <!-- This Entry Reference refers to a goal, intervention, actual 
-         outcome, or some other entry present in the Care Plan
-         that the Health Concern is related to-->
-      <entryRelationship typeCode="REFR">
-        <act classCode="ACT" moodCode="EVN">
-          <templateId root="2.16.840.1.113883.10.20.22.4.122" />
-          <!-- This ID equals the ID of the goal of a pulse 
+<ClinicalDocument>
+  <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+       to demonstrate the locations of the entries across multiple different sections;
+       however, required content like the document header and section LOINC codes
+       has been omitted. -->
+  <component>
+    <structuredBody>
+      <component>
+        <!-- 
+            ********************************************************
+            Health Concern section
+            ********************************************************
+        -->
+        <section>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!-- Health Concern Act of a pneumonia diagnosis -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.132" />
+              <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
+              <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern" />
+              <statusCode code="active" />
+              <effectiveTime value="20130616" />
+              <entryRelationship typeCode="REFR">
+                <!-- Problem Observation (V2) -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2014-06-09" />
+                  <id root="8dfacd73-1682-4cc4-9351-e54ccea83612" />
+                  <code code="29308-4" 
+                    codeSystem="2.16.840.1.113883.6.1" 
+                    codeSystemName="LOINC" 
+                    displayName="Diagnosis"/>
+                  <statusCode code="completed" />
+                  <effectiveTime>
+                    <!-- Date of diagnosis -->
+                    <low value="20130616" />
+                  </effectiveTime>
+                  <value xsi:type="CD" code="233604007" 
+                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED" 
+                    displayName="Pneumonia" />
+                  <!-- This Entry Reference refers to a goal, intervention, actual 
+                       outcome, or some other entry present in the Care Plan
+                       that the Health Concern is related to-->
+                  <entryRelationship typeCode="REFR">
+                    <act classCode="ACT" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                      <!-- This ID equals the ID of the goal of a pulse 
                         ox greater than 92% -->
-          <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
-          <!-- The code is nulled to "NP" Not Present" -->
-          <code nullFlavor="NP" />
-          <statusCode code="completed" />
-        </act>
-      </entryRelationship>
-    </observation>
-  </entryRelationship>
-</act>
-
-...
-
-
-<!-- 
-  ********************************************************
-  Expected Outcomes/Goals section
-  ********************************************************
--->
-
-...
-
-
-<entry>
-  <!-- This is an observation about the expected outcome of a pulse ox reading
-       of 92 or greater.  The Id is the same as the ID as the ID of the 
-       pneumonia problem above  -->
-  <observation classCode="OBS" moodCode="GOL">
-    <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
-    <code code="59408-5" 
-          codeSystem="2.16.840.1.113883.6.1" 
-          codeSystemName="LOINC" 
-          displayName="Oxygen saturation in Arterial blood by Pulse oximetry"/>
-    <statusCode code="active" />
-    <value xsi:type="IVL_PQ">
-      <low value="92" unit="%" />
-    </value>
-    <!-- There could be another Entry Reference here referring to the 
-            related health concern, actual outcome, or intervention -->
-    ...
-    
-  
-  </observation>
-</entry>
-...
+                      <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+                      <!-- The code is nulled to "NP" Not Present" -->
+                      <code nullFlavor="NP" />
+                      <statusCode code="completed" />
+                    </act>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+        <!-- 
+            ********************************************************
+            Expected Outcomes/Goals section
+            ********************************************************
+        -->
+          <entry>
+            <!-- This is an observation about the expected outcome of a pulse ox reading
+                 of 92 or greater.  The Id is the same as the ID as the ID of the 
+                 pneumonia problem above  -->
+            <observation classCode="OBS" moodCode="GOL">
+              <id root="3700b3b0-fbed-11e2-b778-0800200c9a66" />
+              <code code="59408-5" 
+                codeSystem="2.16.840.1.113883.6.1" 
+                codeSystemName="LOINC" 
+                displayName="Oxygen saturation in Arterial blood by Pulse oximetry"/>
+              <statusCode code="active" />
+              <value xsi:type="IVL_PQ">
+                <low value="92" unit="%" />
+              </value>
+              <!-- There could be another Entry Reference here referring to the 
+                   related health concern, actual outcome, or intervention -->
+            </observation>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/Health Concern Act Example.xml
+++ b/Guide Examples/Health Concern Act (V2)_2.16.840.1.113883.10.20.22.4.132/Health Concern Act Example.xml
@@ -1,5 +1,5 @@
 <act classCode="ACT" moodCode="EVN">
-  <templateId root="2.16.840.1.113883.10.20.22.4.132" extension=�2015-08-01� />
+  <templateId root="2.16.840.1.113883.10.20.22.4.132" extension="2015-08-01" />
   <id root="4eab0e52-dd7d-4285-99eb-72d32ddb195c" />
   <code code="75310-3" 
         codeSystem="2.16.840.1.113883.6.1" 

--- a/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/Hospital Admission Diagnosis (V3) Example.xml
+++ b/Guide Examples/Hospital Admission Diagnosis (V3)_2.16.840.1.113883.10.20.22.4.34/Hospital Admission Diagnosis (V3) Example.xml
@@ -9,7 +9,7 @@
   <entryRelationship typeCode="SUBJ" inversionInd="false">
     <observation classCode="OBS" moodCode="EVN">
       <!-- Problem observation template -->
-      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension=�2015-08-01� />
+      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
                 ...
             
         

--- a/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal Care Wound Observation Example.xml
+++ b/Guide Examples/Longitudinal Care Wound Observation (V2)_2.16.840.1.113883.10.20.22.4.114/Longitudinal Care Wound Observation Example.xml
@@ -1,7 +1,7 @@
 <entry>
   <observation classCode="OBS" moodCode="EVN">
     <!-- Wound Observation template -->
-    <templateId root="2.16.840.1.113883.10.20.22.4.114" extension=�2015-08-01� />
+    <templateId root="2.16.840.1.113883.10.20.22.4.114" extension="2015-08-01" />
     <id root="ab1791b0-5c71-11db-b0de-0800200c9a66" />
     <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
     <statusCode code="completed" />

--- a/Guide Examples/MRI Safety Observation_2.16.840.1.113883.10.20.22.4.318/MRI Safety Status.xml
+++ b/Guide Examples/MRI Safety Observation_2.16.840.1.113883.10.20.22.4.318/MRI Safety Status.xml
@@ -2,7 +2,7 @@
 <observation classCode="OBS" moodCode="EVN">
   <templateId root="2.16.840.1.113883.10.20.22.4.318" extension="2019-06-21"/>
   <code code="C106044" displayName="MRI Safety Status" 
-            codeSystem="2.16.840.1.113883.3.26.1.1"codeSystemName="NCI Thesaurus"/>
+            codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
   <value xsi:type="CD" code="C113844" codeSystem="2.16.840.1.113883.3.26.1.1"
               displayName="Labeling does not contain MRI Safety Information" 
               codeSystemName="NCI Thesaurus" sdtc:valueSet="2.16.840.1.113762.1.4.1021.46">

--- a/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/Medication Free Text Sig Example.xml
+++ b/Guide Examples/Medication Free Text Sig_2.16.840.1.113883.10.20.22.4.147/Medication Free Text Sig Example.xml
@@ -1,6 +1,6 @@
 <!-- moodCode matches the parent substanceAdministration EVN or INT -->
-<substanceAdministration classCode=�SBADM� moodCode=�EVN�>
-  <templateId root=�2.16.840.1.113883.10.20.22.4.147�/>
+<substanceAdministration classCode="SBADM" moodCode="EVN">
+  <templateId root="2.16.840.1.113883.10.20.22.4.147"/>
   <code code="76662-6" 
           codeSystem="2.16.840.1.113883.6.1" 
           codeSystemName="LOINC" 
@@ -11,7 +11,7 @@
   </text>
   <consumable>
     <manufacturedProduct>
-      <manufacturedLabeledDrug nullFlavor=�NA�/>
+      <manufacturedLabeledDrug nullFlavor="NA"/>
     </manufacturedProduct>
   </consumable>
 </substanceAdministration>

--- a/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/Model Number.xml
+++ b/Guide Examples/Model Number Observation_2.16.840.1.113883.10.20.22.4.317/Model Number.xml
@@ -1,7 +1,7 @@
     
 <observation classCode="OBS" moodCode="EVN">
   <templateId root="2.16.840.1.113883.10.20.22.4.317" extension="2019-06-21"/>
-  <code code="C99285"displayName="Model Number" 
+  <code code="C99285" displayName="Model Number" 
           codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/>
   <value xsi:type="ED">
     <reference value="#ModelNumber_1"/>

--- a/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Callback Contact Example.xml
+++ b/Guide Examples/Referral Note (V2)_2.16.840.1.113883.10.20.22.1.14/Referral Note Callback Contact Example.xml
@@ -2,7 +2,7 @@
   <time value="20050329224411+0500" />
   <associatedEntity classCode="ASSIGNED">
     <id extension="99999999" root="2.16.840.1.113883.4.6" />
-    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic &amp; Osteopathic Physicians" />
     <addr>
       <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
       <city>Ann Arbor</city>

--- a/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
+++ b/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
@@ -9,15 +9,14 @@
         codeSystem="2.16.840.1.113883.6.1" 
         codeSystemName="LOINC" 
         displayName="Alcoholic drinks per day"></translation>
-    <statusCode code="completed" />
-    <effectiveTime>
-      <low value="20120215" />
-    </effectiveTime>
-    <value xsi:type="PQ" value="12" />
-    <author typeCode="AUT">
-      <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-    ...
-  
-        
-    </author>
-  </observation>
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="20120215" />
+  </effectiveTime>
+  <value xsi:type="PQ" value="12" />
+  <author typeCode="AUT">
+    <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+    <!-- ... -->
+  </author>
+</observation>

--- a/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/Text Observation Example.xml
+++ b/Guide Examples/Text Observation_2.16.840.1.113883.10.20.6.2.12/Text Observation Example.xml
@@ -1,25 +1,27 @@
-<text>
-  <paragraph>
-    <caption>Finding</caption>
-    <content ID="Fndng2">The cardiomediastinum is within normal limits. The trachea is midline. The previously described opacity at the medial right lung base has cleared. There are no new infiltrates. There is a new round density at the left hilus, superiorly (diameter about 45mm). A CT scan is recommended for further evaluation. The pleural spaces are clear. The visualized musculoskeletal structures and the upper abdomen are stable and unremarkable.</content>
-  </paragraph>
-  ...
-
-
-</text>
-<entry>
-  <observation classCode="OBS" moodCode="EVN">
-    <!-- Text Observation -->
-    <templateId root="2.16.840.1.113883.10.20.6.2.12"/>
-    <code code="121071" codeSystem="1.2.840.10008.2.16.4" 
-          codeSystemName="DCM" displayName="Finding"/>
-    <value xsi:type="ED">
-      <reference value="#Fndng2"/>
-    </value>
+<section>
+  <text>
+    <paragraph>
+      <caption>Finding</caption>
+      <content ID="Fndng2">The cardiomediastinum is within normal limits. The trachea is midline. The previously described opacity at the medial right lung base has cleared. There are no new infiltrates. There is a new round density at the left hilus, superiorly (diameter about 45mm). A CT scan is recommended for further evaluation. The pleural spaces are clear. The visualized musculoskeletal structures and the upper abdomen are stable and unremarkable.</content>
+    </paragraph>
     ...
-    
-        
-    <!-- entryRelationships to SOP Instance Observations and Quantity 
-         Measurement Observations may go here -->
-  </observation>
-</entry>
+  
+  
+  </text>
+  <entry>
+    <observation classCode="OBS" moodCode="EVN">
+      <!-- Text Observation -->
+      <templateId root="2.16.840.1.113883.10.20.6.2.12"/>
+      <code code="121071" codeSystem="1.2.840.10008.2.16.4" 
+            codeSystemName="DCM" displayName="Finding"/>
+      <value xsi:type="ED">
+        <reference value="#Fndng2"/>
+      </value>
+      ...
+      
+          
+      <!-- entryRelationships to SOP Instance Observations and Quantity 
+           Measurement Observations may go here -->
+    </observation>
+  </entry>
+</section>

--- a/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary Callback Contact Example.xml
+++ b/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary Callback Contact Example.xml
@@ -2,7 +2,7 @@
   <time value="20050329224411+0500" />
   <associatedEntity classCode="ASSIGNED">
     <id extension="99999999" root="2.16.840.1.113883.4.6" />
-    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic & Osteopathic Physicians" />
+    <code code="200000000X" codeSystem="2.16.840.1.113883.6.101" displayName="Allopathic &amp; Osteopathic Physicians" />
     <addr>
       <streetAddressLine>1002 Healthcare Drive </streetAddressLine>
       <city>Ann Arbor</city>

--- a/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary participant (Support) Example.xml
+++ b/Guide Examples/Transfer Summary (V2)_2.16.840.1.113883.10.20.22.1.13/Transfer Summary participant (Support) Example.xml
@@ -1,49 +1,52 @@
-<participant typeCode="IND">
-  <time xsi:type="IVL_TS">
-    <low value="19590101" />
-    <high value="20111025" />
-  </time>
-  <associatedEntity classCode="ECON">
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
-    <addr>
-      <streetAddressLine>17 Daws Rd.</streetAddressLine>
-      <city>Ann Arbor</city>
-      <state>MI</state>
-      <postalCode>97857</postalCode>
-      <country>US</country>
-    </addr>
-    <telecom value="tel:(999)555-1212" use="WP" />
-    <associatedPerson>
-      <name>
-        <prefix>Mrs.</prefix>
-        <given>Martha</given>
-        <family>Jones</family>
-      </name>
-    </associatedPerson>
-  </associatedEntity>
-</participant>
-<participant typeCode="IND">
-  <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
-  <time xsi:type="IVL_TS">
-    <low value="19590101" />
-    <high value="20111025" />
-  </time>
-  <associatedEntity classCode="CAREGIVER">
-    <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
-    <addr>
-      <streetAddressLine>17 Daws Rd.</streetAddressLine>
-      <city>Ann Arbor</city>
-      <state>MI</state>
-      <postalCode>97857</postalCode>
-      <country>US</country>
-    </addr>
-    <telecom value="tel:(999)555-1212" use="WP" />
-    <associatedPerson>
-      <name>
-        <prefix>Mrs.</prefix>
-        <given>Martha</given>
-        <family>Jones</family>
-      </name>
-    </associatedPerson>
-  </associatedEntity>
-</participant>
+<ClinicalDocument>
+  <!-- ... -->
+  <participant typeCode="IND">
+    <time xsi:type="IVL_TS">
+      <low value="19590101" />
+      <high value="20111025" />
+    </time>
+    <associatedEntity classCode="ECON">
+      <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+      <addr>
+        <streetAddressLine>17 Daws Rd.</streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>97857</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom value="tel:(999)555-1212" use="WP" />
+      <associatedPerson>
+        <name>
+          <prefix>Mrs.</prefix>
+          <given>Martha</given>
+          <family>Jones</family>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+  <participant typeCode="IND">
+    <functionCode code="407543004" displayName="Primary Carer" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" />
+    <time xsi:type="IVL_TS">
+      <low value="19590101" />
+      <high value="20111025" />
+    </time>
+    <associatedEntity classCode="CAREGIVER">
+      <code code="MTH" codeSystem="2.16.840.1.113883.5.111" />
+      <addr>
+        <streetAddressLine>17 Daws Rd.</streetAddressLine>
+        <city>Ann Arbor</city>
+        <state>MI</state>
+        <postalCode>97857</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom value="tel:(999)555-1212" use="WP" />
+      <associatedPerson>
+        <name>
+          <prefix>Mrs.</prefix>
+          <given>Martha</given>
+          <family>Jones</family>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+</ClinicalDocument>

--- a/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US Realm Date and Time Example.xml
+++ b/Guide Examples/US Realm Date and Time (DTM.US.FIELDED)_2.16.840.1.113883.10.20.22.5.4/US Realm Date and Time Example.xml
@@ -1,8 +1,12 @@
-<!-- Common values for date/time elements would range in precision to the day YYYYMMDD to precision to the second with a time zone offset YYYYMMDDHHMMSS - ZZzz -->
-<!-- time element with TS data type precise to the day for a birthdate -->
-<time value=�19800531�/>
-<!-- effectiveTime element with IVL<TS> data type precise to the second for an observation -->
-<effectiveTime>
-  <low value='20110706122735-0800'/>
-  <high value='20110706122815-0800'/>
-</effectiveTime>
+<observation classCode="OBS" moodCode="EVN">
+  <!-- effectiveTime element with IVL<TS> data type precise to the second for an observation -->
+  <effectiveTime>
+    <low value="20110706122735-0800"/>
+    <high value="20110706122815-0800"/>
+  </effectiveTime>
+  <author>
+    <!-- Common values for date/time elements would range in precision to the day YYYYMMDD to precision to the second with a time zone offset YYYYMMDDHHMMSS - ZZzz -->
+    <!-- time element with TS data type precise to the day for a birthdate -->
+    <time value="19800531"/>
+  </author>
+</observation>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Supporting Person participant Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/Supporting Person participant Example.xml
@@ -1,42 +1,45 @@
-<participant typeCode="IND">
-  <!-- typeCode "IND" represents an individual -->
-  <associatedEntity classCode="NOK">
-    <!-- classCode "NOK" represents the patient's next of kin-->
-    <addr use="HP">
-      <streetAddressLine>2222 Home Street</streetAddressLine>
-      <city>Beaverton</city>
-      <state>OR</state>
-      <postalCode>97867</postalCode>
-      <country>US</country>
-    </addr>
-    <telecom value="tel:+1(555)555-2008" use="MC" />
-    <associatedPerson>
-      <name>
-        <given>Boris</given>
-        <given qualifier="CL">Bo</given>
-        <family>Betterhalf</family>
-      </name>
-    </associatedPerson>
-  </associatedEntity>
-</participant>
-<!-- Entities playing multiple roles are recorded in multiple participants -->
-<participant typeCode="IND">
-  <associatedEntity classCode="ECON">
-    <!-- classCode "ECON" represents an emergency contact -->
-    <addr use="HP">
-      <streetAddressLine>2222 Home Street</streetAddressLine>
-      <city>Beaverton</city>
-      <state>OR</state>
-      <postalCode>97867</postalCode>
-      <country>US</country>
-    </addr>
-    <telecom value="tel:+1(555)555-2008" use="MC" />
-    <associatedPerson>
-      <name>
-        <given>Boris</given>
-        <given qualifier="CL">Bo</given>
-        <family>Betterhalf</family>
-      </name>
-    </associatedPerson>
-  </associatedEntity>
-</participant>
+<ClinicalDocument>
+  <!-- ... -->
+  <participant typeCode="IND">
+    <!-- typeCode "IND" represents an individual -->
+    <associatedEntity classCode="NOK">
+      <!-- classCode "NOK" represents the patient's next of kin-->
+      <addr use="HP">
+        <streetAddressLine>2222 Home Street</streetAddressLine>
+        <city>Beaverton</city>
+        <state>OR</state>
+        <postalCode>97867</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom value="tel:+1(555)555-2008" use="MC" />
+      <associatedPerson>
+        <name>
+          <given>Boris</given>
+          <given qualifier="CL">Bo</given>
+          <family>Betterhalf</family>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+  <!-- Entities playing multiple roles are recorded in multiple participants -->
+  <participant typeCode="IND">
+    <associatedEntity classCode="ECON">
+      <!-- classCode "ECON" represents an emergency contact -->
+      <addr use="HP">
+        <streetAddressLine>2222 Home Street</streetAddressLine>
+        <city>Beaverton</city>
+        <state>OR</state>
+        <postalCode>97867</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom value="tel:+1(555)555-2008" use="MC" />
+      <associatedPerson>
+        <name>
+          <given>Boris</given>
+          <given qualifier="CL">Bo</given>
+          <family>Betterhalf</family>
+        </name>
+      </associatedPerson>
+    </associatedEntity>
+  </participant>
+</ClinicalDocument>

--- a/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget Example.xml
+++ b/Guide Examples/US Realm Header (V3)_2.16.840.1.113883.10.20.22.1.1/recordTarget Example.xml
@@ -36,10 +36,10 @@
       <religiousAffiliationCode code="1013" displayName="Christian (non-Catholic, non-specific)" codeSystem="2.16.840.1.113883.5.1076" codeSystemName="HL7 Religious Affiliation" />
       <!-- CDC Race and Ethnicity code set contains the five minimum
                  race and ethnicity categories defined by OMB Standards -->
-      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
       <!-- The raceCode extension is only used if raceCode is valued -->
-      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
-      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
       <guardian>
         <code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty" />
         <addr use="HP">

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informationRecipient.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document informationRecipient.xml
@@ -1,55 +1,58 @@
-<!-- The document is intended for multiple recipients, Adam himself and his PCP physician. -->
-<informationRecipient>
-  <intendedRecipient>
-    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+<ClinicalDocument>
+  <!-- ... -->
+  <!-- The document is intended for multiple recipients, Adam himself and his PCP physician. -->
+  <informationRecipient>
+    <intendedRecipient>
+      <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
 				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
-    <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
-    <informationRecipient>
-      <name>
-        <given>Adam</given>
-        <family>Everyman</family>
-      </name>
-    </informationRecipient>
-    <receivedOrganization>
-      <!-- id using HL7 example OID. -->
-      <id extension="999.3" root="2.16.840.1.113883.19" />
-      <name>MyPersonalHealthRecord.Com</name>
-    </receivedOrganization>
-  </intendedRecipient>
-</informationRecipient>
-<informationRecipient>
-  <intendedRecipient>
-    <!-- Unique/Trusted id using HL7 example OID. -->
-    <id extension="999.4" root="2.16.840.1.113883.19" />
-    <!-- The physician's NPI number -->
-    <id extension="1122334455" root="2.16.840.1.113883.4.6" />
-    <!-- The physician's Direct Address -->
-    <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
-				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
-    <id extension="DrP@direct.sampleHISP2.com" root="2.16.123.123.12345.4321" />
-    <telecom use="WP" value="tel:(781)555-1212" />
-    <telecom use="WP" value="mailto:DrP@direct.sampleHISP2.com" />
-    <informationRecipient>
-      <name>
-        <prefix>Dr.</prefix>
-        <given>Patricia</given>
-        <family>Primary</family>
-      </name>
-    </informationRecipient>
-    <receivedOrganization>
+      <id extension="adameveryman@direct.sampleHISP.com" root="2.16.123.123.12345.1234" />
+      <informationRecipient>
+        <name>
+          <given>Adam</given>
+          <family>Everyman</family>
+        </name>
+      </informationRecipient>
+      <receivedOrganization>
+        <!-- id using HL7 example OID. -->
+        <id extension="999.3" root="2.16.840.1.113883.19" />
+        <name>MyPersonalHealthRecord.Com</name>
+      </receivedOrganization>
+    </intendedRecipient>
+  </informationRecipient>
+  <informationRecipient>
+    <intendedRecipient>
       <!-- Unique/Trusted id using HL7 example OID. -->
-      <id extension="999.2" root="2.16.840.1.113883.19" />
-      <!-- NPI for the organization -->
-      <id extension="1234567890" root="2.16.840.1.113883.4.6" />
-      <name>Good Health Internal Medicine</name>
+      <id extension="999.4" root="2.16.840.1.113883.19" />
+      <!-- The physician's NPI number -->
+      <id extension="1122334455" root="2.16.840.1.113883.4.6" />
+      <!-- The physician's Direct Address -->
+      <!-- Identifier based on the person's Direct Address which is a secure and trusted mechanism for identifying 
+				a person discretely. The root of the id is the OID of the HISP Assigning Authority for the Direct Address-->
+      <id extension="DrP@direct.sampleHISP2.com" root="2.16.123.123.12345.4321" />
       <telecom use="WP" value="tel:(781)555-1212" />
-      <addr>
-        <streetAddressLine>100 Health Drive</streetAddressLine>
-        <city>Boston</city>
-        <state>MA</state>
-        <postalCode>02368</postalCode>
-        <country>USA</country>
-      </addr>
-    </receivedOrganization>
-  </intendedRecipient>
-</informationRecipient>
+      <telecom use="WP" value="mailto:DrP@direct.sampleHISP2.com" />
+      <informationRecipient>
+        <name>
+          <prefix>Dr.</prefix>
+          <given>Patricia</given>
+          <family>Primary</family>
+        </name>
+      </informationRecipient>
+      <receivedOrganization>
+        <!-- Unique/Trusted id using HL7 example OID. -->
+        <id extension="999.2" root="2.16.840.1.113883.19" />
+        <!-- NPI for the organization -->
+        <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+        <name>Good Health Internal Medicine</name>
+        <telecom use="WP" value="tel:(781)555-1212" />
+        <addr>
+          <streetAddressLine>100 Health Drive</streetAddressLine>
+          <city>Boston</city>
+          <state>MA</state>
+          <postalCode>02368</postalCode>
+          <country>USA</country>
+        </addr>
+      </receivedOrganization>
+    </intendedRecipient>
+  </informationRecipient>
+</ClinicalDocument>

--- a/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document recordTarget Example.xml
+++ b/Guide Examples/US Realm Header for Patient Generated Document (V2)_2.16.840.1.113883.10.20.29.1/Patient Generated Document recordTarget Example.xml
@@ -36,10 +36,10 @@
       <religiousAffiliationCode code="1013" displayName="Christian (non-Catholic, non-specific)" codeSystem="2.16.840.1.113883.5.1076" codeSystemName="HL7 Religious Affiliation" />
       <!-- CDC Race and Ethnicity code set contains the five minimum
                  race and ethnicity categories defined by OMB Standards -->
-      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
       <!-- The raceCode extension is only used if raceCode is valued -->
-      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
-      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race & Ethnicity - CDC" />
+      <sdtc:raceCode code="2076-8" displayName="Hawaiian or Other Pacific Islander" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
+      <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" />
       <guardian>
         <id root="2.16.840.1.113883.4.1" extension="111-22-3333" />
         <code code="POWATT" displayName="Power of Attorney" codeSystem="2.16.840.1.113883.1.11.19830" codeSystemName="ResponsibleParty" />

--- a/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/README.md
+++ b/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/README.md
@@ -1,3 +1,6 @@
+## Example Moved
+See [CDA Search Header Examples](https://cdasearch.hl7.org/sections/Header)
+
 ## SDWG Supported Sample from Implementation Guide
 
 The initial load of this repository in January 2021 includes all examples (figures) from the June 2019 Errata published PDF of C-CDA 2.1 and 2019 release of C-CDA Companion Guide. 

--- a/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US Realm Patient Name Example.xml
+++ b/Guide Examples/US Realm Patient Name (PTN.US.FIELDED)_2.16.840.1.113883.10.20.22.5.1/US Realm Patient Name Example.xml
@@ -1,1 +1,0 @@
-See [CDA Search Header Examples](https://cdasearch.hl7.org/sections/Header)

--- a/Header/Patient Deceased/Patient Deceased Extension(C-CDA2.1).xml
+++ b/Header/Patient Deceased/Patient Deceased Extension(C-CDA2.1).xml
@@ -23,7 +23,7 @@
             <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" displayName="Male" codeSystemName="AdministrativeGender"/>
             <birthTime value="19521022"/>
             <!-- A full CDA example may include the Deceased Observation to indicate cause of death -->
-            <!-- A Deceased Observation may be present in any section -- Problem List is a suitable location -->
+            <!-- A Deceased Observation may be present in any section; Problem List is a suitable location -->
 	    <!-- Stylesheets are strongly recommended to include human viewable rendering of the deceased indication and time when present -->
 	    <!-- Systems may send deceased indication, time, or both. Sending only time is not recommeded. -->
             <sdtc:deceasedInd value="true" />

--- a/Health Concerns/Health Concerns Link to Problems Section with linkHTML/Health Concerns Link to Problems Section with linkHTML(C-CDA2.1).xml
+++ b/Health Concerns/Health Concerns Link to Problems Section with linkHTML/Health Concerns Link to Problems Section with linkHTML(C-CDA2.1).xml
@@ -1,141 +1,151 @@
-<component>
-    <section>
-        <!-- Health Concerns Section (V2) -->
-        <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.58"/>
-        <code code="75310-3" displayName="Health Concerns Document" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
-        <title>Health Concerns Section</title>
-        <text>
-            <table border="1" width="100%">
-                <thead>
-                    <tr>
-                        <th>Health Concern</th>
-                        <th>Date</th>
-                        <th>Related Problem</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ID="Concern1">
-                        <td ID="Concern1Issue1">Patient is concerned about being contagious and infecting roommate.</td>
-                        <td>Concern from 03/02/2014</td>
-                        <!-- Providing this as a link to the related problem in problem list is an option using base CDA implementation guidance. -->
-                        <td><linkHtml href="#Problem1">Community Acquired Pneumonia</linkHtml></td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <entry>
-            <!-- Health Concern Act -->
-            <act classCode="ACT" moodCode="EVN">
-                <templateId root="2.16.840.1.113883.10.20.22.4.132" extension="2015-08-01"/>
-                <templateId root="2.16.840.1.113883.10.20.22.4.132"/>
-                <id root="63c5e137-3024-46cc-951f-885ec69d9030"/>
-                <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern"/>
-                <!-- This Health Concern has a statusCode of active because it is an active concern -->
-                <statusCode code="active"/>
-                <!-- The effective time is the date that the Health Concern started being followed - 
-							 this does not necessarily correlate to the onset date of the contained health issues-->
-                <effectiveTime value="20140302"/>
-                <entryRelationship typeCode="REFR">
-                    <observation classCode="OBS" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
-                        <id root="59c5ca3e-662f-4e33-943f-2777ebc6227e"/>
-                        <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
-                            <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
-                        </code>
-                        <text>
-                            <reference value="#Concern1" />
-                        </text>
-                        <statusCode code="completed"/>
-                        <effectiveTime>
-                            <low value="20140302"/>
-                        </effectiveTime>
-                        <value xsi:type="CD" nullFlavor="OTH">
-			    <originalText>
-			        <reference value="#Concern1Issue1" />
-			    </originalText>
-                        </value>						
-                    </observation>
-                </entryRelationship>
-                <!-- Health Concern Problem: Community Acquired Pneumonia -->
-                <!-- This Entry Reference refers to a problem observation present in Problem List that the Health Concern is related to-->
-                <entryRelationship typeCode="REFR">
-                    <act classCode="ACT" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
-                        <!-- This ID equals the ID of the Community Acquired Pneumonia problem -->
-                        <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e" />
-                        <!-- The code is nulled to "NP" Not Present" -->
-                        <code nullFlavor="NP"/>
-                        <statusCode code="completed" />
-                    </act>
-                </entryRelationship>
-            </act>
-        </entry>
-    </section>
-</component>
-<component> 
-    <section>
-        <!-- Located elsewhere in the document -->
-        <!-- Taken directly (changed observation/id) from prior example https://github.com/brettmarquard/HL7-C-CDA-Task-Force-Examples/blob/master/Problem_List_Active_Problem.xml -->
-        <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
-        <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" displayName="Problem List"/>
-        <title>Problem List</title>
-        <text>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Dates</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ID="Problem1">
-                        <td>Community Acquired Pneumonia</td>
-                        <td>
-                            <content>Onset: 02/27/2014</content>
-                        </td>
-                        <td>Active</td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <entry>
-            <act classCode="ACT" moodCode="EVN">
-                <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
-                <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
-                <id root="102ca2e9-884c-4523-a2b4-1b6c3469c397" />
-                <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
-                <!-- Since this is an active problem, the concern status is active. -->
-                <!-- While clinicians can track resolved problems, generally active problems will have active concern status and resolved concerns will be completed -->
-                <statusCode code="active" />
-                <effectiveTime>
-                    <!-- This equates to the time the concern was authored in the patient's chart. This may frequently be an EHR timestamp-->
-                    <low value="20140302124536-0500" />
-                </effectiveTime>
-                <entryRelationship typeCode="SUBJ">
-                    <observation classCode="OBS" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
-                        <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e"/>
-                        <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
-                            <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
-                        </code>
-                        <text>
-                            <reference value="#Problem1" />
-                        </text>
-                        <statusCode code="completed"/>
-                        <effectiveTime>
-                            <!-- This represents the date of biological onset. -->
-                            <low value="20140227"/>
-                        </effectiveTime>
-                        <!-- This is a SNOMED code as the primary vocabulary for problem lists-->
-                        <value xsi:type="CD" code="385093006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Community Acquired Pneumonia"/>							
-                    </observation>
-                </entryRelationship>
-            </act>
-        </entry>
-    </section>
-</component>
+<ClinicalDocument>
+    <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+       to demonstrate the locations of the entries across multiple different sections;
+       however, required content like the document header and section LOINC codes
+       has been omitted. -->
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <!-- Health Concerns Section (V2) -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58"/>
+                    <code code="75310-3" displayName="Health Concerns Document" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns Section</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Date</th>
+                                    <th>Related Problem</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="Concern1">
+                                    <td ID="Concern1Issue1">Patient is concerned about being contagious and infecting roommate.</td>
+                                    <td>Concern from 03/02/2014</td>
+                                    <!-- Providing this as a link to the related problem in problem list is an option using base CDA implementation guidance. -->
+                                    <td><linkHtml href="#Problem1">Community Acquired Pneumonia</linkHtml></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <!-- Health Concern Act -->
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132" extension="2015-08-01"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"/>
+                            <id root="63c5e137-3024-46cc-951f-885ec69d9030"/>
+                            <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern"/>
+                            <!-- This Health Concern has a statusCode of active because it is an active concern -->
+                            <statusCode code="active"/>
+                            <!-- The effective time is the date that the Health Concern started being followed - 
+            							 this does not necessarily correlate to the onset date of the contained health issues-->
+                            <effectiveTime value="20140302"/>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="59c5ca3e-662f-4e33-943f-2777ebc6227e"/>
+                                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
+                                        <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#Concern1" />
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20140302"/>
+                                    </effectiveTime>
+                                    <value xsi:type="CD" nullFlavor="OTH">
+            			    <originalText>
+            			        <reference value="#Concern1Issue1" />
+            			    </originalText>
+                                    </value>						
+                                </observation>
+                            </entryRelationship>
+                            <!-- Health Concern Problem: Community Acquired Pneumonia -->
+                            <!-- This Entry Reference refers to a problem observation present in Problem List that the Health Concern is related to-->
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <!-- This ID equals the ID of the Community Acquired Pneumonia problem -->
+                                    <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e" />
+                                    <!-- The code is nulled to "NP" Not Present" -->
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed" />
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component> 
+                <section>
+                    <!-- Located elsewhere in the document -->
+                    <!-- Taken directly (changed observation/id) from prior example https://github.com/brettmarquard/HL7-C-CDA-Task-Force-Examples/blob/master/Problem_List_Active_Problem.xml -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" displayName="Problem List"/>
+                    <title>Problem List</title>
+                    <text>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Dates</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="Problem1">
+                                    <td>Community Acquired Pneumonia</td>
+                                    <td>
+                                        <content>Onset: 02/27/2014</content>
+                                    </td>
+                                    <td>Active</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <id root="102ca2e9-884c-4523-a2b4-1b6c3469c397" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
+                            <!-- Since this is an active problem, the concern status is active. -->
+                            <!-- While clinicians can track resolved problems, generally active problems will have active concern status and resolved concerns will be completed -->
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <!-- This equates to the time the concern was authored in the patient's chart. This may frequently be an EHR timestamp-->
+                                <low value="20140302124536-0500" />
+                            </effectiveTime>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e"/>
+                                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
+                                        <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#Problem1" />
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <!-- This represents the date of biological onset. -->
+                                        <low value="20140227"/>
+                                    </effectiveTime>
+                                    <!-- This is a SNOMED code as the primary vocabulary for problem lists-->
+                                    <value xsi:type="CD" code="385093006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Community Acquired Pneumonia"/>							
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/Health Concerns/Health Concerns Link to Problems Section/Health Concerns Link to Problems Section(C-CDA2.1).xml
+++ b/Health Concerns/Health Concerns Link to Problems Section/Health Concerns Link to Problems Section(C-CDA2.1).xml
@@ -1,141 +1,151 @@
-<component>
-    <section>
-        <!-- Health Concerns Section (V2)-->
-        <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.58"/>
-        <code code="75310-3" displayName="Health Concerns Document" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
-        <title>Health Concerns Section</title>
-        <text>
-            <table border="1" width="100%">
-                <thead>
-                    <tr>
-                        <th>Health Concern</th>
-                        <th>Date</th>
-                        <th>Related Problem</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ID="Concern1">
-                        <td ID="Concern1Issue1">Patient is concerned about being contagious and infecting roommate.</td>
-                        <td>Concern from 03/02/2014</td>
-                        <!-- Providing this as a link to the related problem in problem list is an option using base CDA implementation guidance. -->
-                        <td>Community Acquired Pneumonia</td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <entry>
-            <!-- Health Concern Act -->
-            <act classCode="ACT" moodCode="EVN">
-                <templateId root="2.16.840.1.113883.10.20.22.4.132" extension="2015-08-01"/>
-                <templateId root="2.16.840.1.113883.10.20.22.4.132"/>
-                <id root="63c5e137-3024-46cc-951f-885ec69d9030"/>
-                <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern"/>
-                <!-- This Health Concern has a statusCode of active because it is an active concern -->
-                <statusCode code="active"/>
-                <!-- The effective time is the date that the Health Concern started being followed - 
-							 this does not necessarily correlate to the onset date of the contained health issues-->
-                <effectiveTime value="20140302"/>
-                <entryRelationship typeCode="REFR">
-                    <observation classCode="OBS" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
-                        <id root="59c5ca3e-662f-4e33-943f-2777ebc6227e"/>
-                        <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
-                            <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
-                        </code>
-                        <text>
-                            <reference value="#Concern1" />
-                        </text>
-                        <statusCode code="completed"/>
-                        <effectiveTime>
-                            <low value="20140302"/>
-                        </effectiveTime>
-                        <value xsi:type="CD" nullFlavor="OTH">
-			<originalText>
-				<reference value="#Concern1Issue1" />
-			</originalText>
-                        </value>						
-                    </observation>
-                </entryRelationship>
-                <!-- Health Concern Problem: Community Acquired Pneumonia -->
-                <!-- This Entry Reference refers to a problem observation present in Problem List that the Health Concern is related to-->
-                <entryRelationship typeCode="REFR">
-                    <act classCode="ACT" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.122" />
-                        <!-- This ID equals the ID of the Community Acquired Pneumonia problem -->
-                        <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e" />
-                        <!-- The code is nulled to "NP" Not Present" -->
-                        <code nullFlavor="NP"/>
-                        <statusCode code="completed" />
-                    </act>
-                </entryRelationship>
-            </act>
-        </entry>
-    </section>
-</component>
-<component> 
-    <section>
-        <!-- Located elsewhere in the document -->
-        <!-- Taken directly (changed observation/id) from prior example https://github.com/brettmarquard/HL7-C-CDA-Task-Force-Examples/blob/master/Problem_List_Active_Problem.xml -->
-        <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
-        <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" displayName="Problem List"/>
-        <title>Problem List</title>
-        <text>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Dates</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ID="Problem1">
-                        <td>Community Acquired Pneumonia</td>
-                        <td>
-                            <content>Onset: 02/27/2014</content>
-                        </td>
-                        <td>Active</td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <entry>
-            <act classCode="ACT" moodCode="EVN">
-                <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
-                <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
-                <id root="102ca2e9-884c-4523-a2b4-1b6c3469c397" />
-                <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
-                <!-- Since this is an active problem, the concern status is active. -->
-                <!-- While clinicians can track resolved problems, generally active problems will have active concern status and resolved concerns will be completed -->
-                <statusCode code="active" />
-                <effectiveTime>
-                    <!-- This equates to the time the concern was authored in the patient's chart. This may frequently be an EHR timestamp-->
-                    <low value="20140302124536-0500" />
-                </effectiveTime>
-                <entryRelationship typeCode="SUBJ">
-                    <observation classCode="OBS" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
-                        <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
-                        <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e"/>
-                        <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
-                            <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
-                        </code>
-                        <text>
-                            <reference value="#Problem1" />
-                        </text>
-                        <statusCode code="completed"/>
-                        <effectiveTime>
-                            <!-- This represents the date of biological onset. -->
-                            <low value="20140227"/>
-                        </effectiveTime>
-                        <!-- This is a SNOMED code as the primary vocabulary for problem lists-->
-                        <value xsi:type="CD" code="385093006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Community Acquired Pneumonia"/>							
-                    </observation>
-                </entryRelationship>
-            </act>
-        </entry>
-    </section>
-</component>
+<ClinicalDocument>
+    <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+       to demonstrate the locations of the entries across multiple different sections;
+       however, required content like the document header and section LOINC codes
+       has been omitted. -->
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <!-- Health Concerns Section (V2)-->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58"/>
+                    <code code="75310-3" displayName="Health Concerns Document" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns Section</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Date</th>
+                                    <th>Related Problem</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="Concern1">
+                                    <td ID="Concern1Issue1">Patient is concerned about being contagious and infecting roommate.</td>
+                                    <td>Concern from 03/02/2014</td>
+                                    <!-- Providing this as a link to the related problem in problem list is an option using base CDA implementation guidance. -->
+                                    <td>Community Acquired Pneumonia</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <!-- Health Concern Act -->
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132" extension="2015-08-01"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"/>
+                            <id root="63c5e137-3024-46cc-951f-885ec69d9030"/>
+                            <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern"/>
+                            <!-- This Health Concern has a statusCode of active because it is an active concern -->
+                            <statusCode code="active"/>
+                            <!-- The effective time is the date that the Health Concern started being followed - 
+            							 this does not necessarily correlate to the onset date of the contained health issues-->
+                            <effectiveTime value="20140302"/>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="59c5ca3e-662f-4e33-943f-2777ebc6227e"/>
+                                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
+                                        <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#Concern1" />
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20140302"/>
+                                    </effectiveTime>
+                                    <value xsi:type="CD" nullFlavor="OTH">
+            			<originalText>
+            				<reference value="#Concern1Issue1" />
+            			</originalText>
+                                    </value>						
+                                </observation>
+                            </entryRelationship>
+                            <!-- Health Concern Problem: Community Acquired Pneumonia -->
+                            <!-- This Entry Reference refers to a problem observation present in Problem List that the Health Concern is related to-->
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                                    <!-- This ID equals the ID of the Community Acquired Pneumonia problem -->
+                                    <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e" />
+                                    <!-- The code is nulled to "NP" Not Present" -->
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed" />
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component> 
+                <section>
+                    <!-- Located elsewhere in the document -->
+                    <!-- Taken directly (changed observation/id) from prior example https://github.com/brettmarquard/HL7-C-CDA-Task-Force-Examples/blob/master/Problem_List_Active_Problem.xml -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <code code="11450-4" codeSystem="2.16.840.1.113883.6.1" displayName="Problem List"/>
+                    <title>Problem List</title>
+                    <text>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Dates</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="Problem1">
+                                    <td>Community Acquired Pneumonia</td>
+                                    <td>
+                                        <content>Onset: 02/27/2014</content>
+                                    </td>
+                                    <td>Active</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <id root="102ca2e9-884c-4523-a2b4-1b6c3469c397" />
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6" />
+                            <!-- Since this is an active problem, the concern status is active. -->
+                            <!-- While clinicians can track resolved problems, generally active problems will have active concern status and resolved concerns will be completed -->
+                            <statusCode code="active" />
+                            <effectiveTime>
+                                <!-- This equates to the time the concern was authored in the patient's chart. This may frequently be an EHR timestamp-->
+                                <low value="20140302124536-0500" />
+                            </effectiveTime>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <id root="49c5ca3e-662f-4e33-948f-2777ebc6727e"/>
+                                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
+                                        <translation codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" code="75326-9" displayName="Problem"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#Problem1" />
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <!-- This represents the date of biological onset. -->
+                                        <low value="20140227"/>
+                                    </effectiveTime>
+                                    <!-- This is a SNOMED code as the primary vocabulary for problem lists-->
+                                    <value xsi:type="CD" code="385093006" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Community Acquired Pneumonia"/>							
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/Medical Equipment/Implant UDI Organizer/Implant UDI Organizer (C-CDA R2.1).xml
+++ b/Medical Equipment/Implant UDI Organizer/Implant UDI Organizer (C-CDA R2.1).xml
@@ -177,7 +177,7 @@
 										</observation>
 									</component>
 									<!-- Distinct Identification assigned wherever donation pulled from-->
-									<!-- The distinct identification code may be equivalent to the serial number, lot or batch number, or the donation identification number. 
+									<!-- The distinct identification code may be equivalent to the serial number, lot or batch number, or the donation identification number.  -->
 									<!-- The appropriate value should be provided as the distinct identification code. -->
 									<!-- <component>
 										<observation classCode="OBS" moodCode="EVN">
@@ -201,7 +201,7 @@
 									<component>
 										<observation classCode="OBS" moodCode="EVN">
 											<templateId root="2.16.840.1.113883.10.20.22.4.317" extension="2019-06-21"/>
-											<code code="C99285"displayName="Model Number" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/> 
+											<code code="C99285" displayName="Model Number" codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI Thesaurus"/> 
 											<value xsi:type="ED"> 
 												<reference value="#ModelNumber_1"/>
 											</value> 											

--- a/Medications/Drug Mixture/Drug Mixture (C-CDAR2.1).xml
+++ b/Medications/Drug Mixture/Drug Mixture (C-CDAR2.1).xml
@@ -40,7 +40,7 @@
                 <manufacturedProduct classCode="MANU">
                     <!-- This manufacturedProduct conforms to both the C-CDA Medication Information (V2)
                          template AND the UV Medication Information (detail) template:
-                         https://art-decor.org/art-decor/decor-templates--pharmcda-?section=templates&id=2.16.840.1.113883.10.21.4.11 -->
+                         https://art-decor.org/art-decor/decor-templates%2d%2dpharmcda-?section=templates&id=2.16.840.1.113883.10.21.4.11 -->
                     <templateId root="2.16.840.1.113883.10.20.22.4.23" /> 
                     <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" /> 
                     <templateId root="2.16.840.1.113883.10.21.4.11" />
@@ -132,8 +132,8 @@
                         <!-- aluminum & magnesium hydroxide-simethicone -->
                         <pharm:ingredient classCode="BASE">
                             <!-- The quantity of a mixture's base should generally just use the nullFlavor "QS".
-                                 Note that "QS" isn't part of the set of allowed nullFlavors in CDA R2.0--it's only
-                                 normative in CDA R2.1--but since this element comes from outside the CDA namespace,
+                                 Note that "QS" isn't part of the set of allowed nullFlavors in CDA R2.0—it's only
+                                 normative in CDA R2.1—but since this element comes from outside the CDA namespace,
                                  neither the CDA R2.0 nor the CDA R2.1 validation rules apply to it. -->
                             <pharm:quantity nullFlavor="QS" />
                             <pharm:ingredientSubstance classCode="MMAT" determinerCode="KIND">

--- a/Plan of Treatment/Planned Encounter - Referral/Planned Encounter - Reason for Referral(C-CDAR2.1).xml
+++ b/Plan of Treatment/Planned Encounter - Referral/Planned Encounter - Reason for Referral(C-CDAR2.1).xml
@@ -10,126 +10,136 @@ This example also includes details of the referral as text and Planned Encounter
 there are systems that might very well represent the data in the Plan of Treatment section, based upon the test data statement about Scheduled date.
  -->
 
-<!-- here is the minimally necessary Reason for Referral section with the text showing the scheduled referral
-			note: depending upon how the test data are interpreted the content of the text may vary as regards the Scheduled date.
- -->
-<component>
-    <section>
-        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
-        <code code="42349-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Reason For Referral"/>
-        <title>Reason For Referral</title>
-        <text>Pulmonary function tests, Dr. Penny Puffer, Tel: 555-555-1049, 1047 Healthcare Drive, Portland, OR 97005, Scheduled date: 08/17/2012</text>
-    </section>
-</component>
-<!-- here is the optional section for Plan of Care with the Planned Encounter -->
-<component>
-    <section>
-        <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
-        <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Plan of Care"/>
-        <title>Plan of Care</title>
-        <!-- one Planned Encounter in the human readable text and as a discrete entry -->
-        <text>
-            <!-- this section may contain many different Planned items, so we use the table caption to help identify each -->
-            <table>
-                <caption>Planned Encounters</caption>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Date</th>
-                        <th>Details</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td ID="ID0EFFFFFFCA">
-                            <content ID="ID0EFAAAAACA">Pulmonary Function Tests; Dr. Penny Puffer, Tel: 555-555-1049, 1047 Healthcare Drive, Portland OR 97005</content>
-                        </td>
-                        <td>17-Aug-2012</td>
-                        <td ID="ID0EAAAAAAAAACA">Indication: Costal Chondritis</td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <!-- a planned encounter entry -->
-        <entry>
-            <!-- encounter with moodCode indicating Intent -->
-            <encounter classCode="ENC" moodCode="INT">
-                <!-- Planned Encounter templateId -->
-                <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09"/>
-                <templateId root="2.16.840.1.113883.10.20.22.4.40"/>
-                <id extension="52487" root="1.3.6.1.42424242.4.99930.4.3.4"/>
-                <!-- templateId and id are all that are required or specified in C-CDA R1.1; with C-CDA R2.0 the documentation changes quite a bit -->
-                <!-- code from the Planned Encounter Type value set; 11429006 is reflective of the example data, but local policy and use may result in selection of a different code -->
-                <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="11429006" displayName="consultation">
-                    <!-- referencing back to the text of the type-->
-                    <originalText>
-                        <reference value="#ID0EFAAAAACA"/>
-                    </originalText>
-                </code>
-                <text>
-                    <!-- referencing the entire text -->
-                    <reference value="#ID0EFFFFFFCA"/>
-                </text>
-                <statusCode code="active"/>
-                <effectiveTime>
-                    <!-- appointment requested for Test date + 2 days , so 8/17/2012 -->
-                    <low value="20120817"/>
-                </effectiveTime>
-                <!-- the requested Penny Puffer provider -->
-                <performer typeCode="PRF">
-                    <assignedEntity>
-                        <id extension="3333333333" root="2.16.840.1.113883.4.6"/>
-                        <addr>
-                            <streetAddressLine>1047 Healthcare Dr</streetAddressLine>
-                            <city>Portland</city>
-                            <state>OR</state>
-                            <postalCode>97005</postalCode>
-                            <country>US</country>
-                        </addr>
-                        <telecom value="tel:+1-(555)555-1049"/>
-                        <assignedPerson>
-                            <name>
-                                <prefix>Dr</prefix>
-                                <given>Penny</given>
-                                <family>Puffer</family>
-                            </name>
-                        </assignedPerson>
-                    </assignedEntity>
-                </performer>
-                <!-- Penny Puffer office location as a service delivery location -->
-                <participant typeCode="LOC">
-                    <participantRole classCode="SDLOC">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
-                        <code code="1212-0" codeSystem="2.16.840.1.113883.6.259" displayName="Any Age Mixed Acuity Unit"/>
-                        <telecom nullFlavor="UNK"/>
-                        <playingEntity classCode="PLC">
-                            <name>Dr. Penny Puffer Office</name>
-                        </playingEntity>
-                    </participantRole>
-                </participant>
-                <!-- this references the indication (reason) for the planned encounter; example data suggests the reason was the encounter diagnosis
-					L)	Encounter Diagnosis
-						 - Costal Chondritis, [SNOMED-CT: 64109004], Start: 8/15/2012, Active
-			 -->
-                <entryRelationship typeCode="RSON">
-                    <observation classCode="OBS" moodCode="EVN">
-                        <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09"/>
-                        <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
-                        <id extension="45678" root="1.3.6.1.4.1.42424242.4.99930.4.4.1.2.1"/>
-                        <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="282291009" displayName="Diagnosis"/>
-                        <text>
-                            <reference value="#ID0EAAAAAAAAACA"/>
-                        </text>
-                        <statusCode code="completed"/>
-                        <effectiveTime>
-                            <low value="20120815"/>
-                        </effectiveTime>
-                        <!-- includes the code for Costal Chondritis -->
-                        <value xsi:type="CD" code="64109004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Costal Chondritis"/>
-                    </observation>
-                </entryRelationship>
-            </encounter>
-        </entry>
-    </section>
-</component>
+<ClinicalDocument>
+    <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+         to demonstrate the locations of the entries across multiple different sections;
+         however, required content like the document header and section LOINC codes
+         has been omitted. -->
+    <component>
+        <structuredBody>
+            <!-- here is the minimally necessary Reason for Referral section with the text showing the scheduled referral
+            			note: depending upon how the test data are interpreted the content of the text may vary as regards the Scheduled date.
+             -->
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <code code="42349-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Reason For Referral"/>
+                    <title>Reason For Referral</title>
+                    <text>Pulmonary function tests, Dr. Penny Puffer, Tel: 555-555-1049, 1047 Healthcare Drive, Portland, OR 97005, Scheduled date: 08/17/2012</text>
+                </section>
+            </component>
+            <!-- here is the optional section for Plan of Care with the Planned Encounter -->
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <code code="18776-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Plan of Care"/>
+                    <title>Plan of Care</title>
+                    <!-- one Planned Encounter in the human readable text and as a discrete entry -->
+                    <text>
+                        <!-- this section may contain many different Planned items, so we use the table caption to help identify each -->
+                        <table>
+                            <caption>Planned Encounters</caption>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Date</th>
+                                    <th>Details</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td ID="ID0EFFFFFFCA">
+                                        <content ID="ID0EFAAAAACA">Pulmonary Function Tests; Dr. Penny Puffer, Tel: 555-555-1049, 1047 Healthcare Drive, Portland OR 97005</content>
+                                    </td>
+                                    <td>17-Aug-2012</td>
+                                    <td ID="ID0EAAAAAAAAACA">Indication: Costal Chondritis</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <!-- a planned encounter entry -->
+                    <entry>
+                        <!-- encounter with moodCode indicating Intent -->
+                        <encounter classCode="ENC" moodCode="INT">
+                            <!-- Planned Encounter templateId -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.40"/>
+                            <id extension="52487" root="1.3.6.1.42424242.4.99930.4.3.4"/>
+                            <!-- templateId and id are all that are required or specified in C-CDA R1.1; with C-CDA R2.0 the documentation changes quite a bit -->
+                            <!-- code from the Planned Encounter Type value set; 11429006 is reflective of the example data, but local policy and use may result in selection of a different code -->
+                            <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="11429006" displayName="consultation">
+                                <!-- referencing back to the text of the type-->
+                                <originalText>
+                                    <reference value="#ID0EFAAAAACA"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <!-- referencing the entire text -->
+                                <reference value="#ID0EFFFFFFCA"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <!-- appointment requested for Test date + 2 days , so 8/17/2012 -->
+                                <low value="20120817"/>
+                            </effectiveTime>
+                            <!-- the requested Penny Puffer provider -->
+                            <performer typeCode="PRF">
+                                <assignedEntity>
+                                    <id extension="3333333333" root="2.16.840.1.113883.4.6"/>
+                                    <addr>
+                                        <streetAddressLine>1047 Healthcare Dr</streetAddressLine>
+                                        <city>Portland</city>
+                                        <state>OR</state>
+                                        <postalCode>97005</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom value="tel:+1-(555)555-1049"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <prefix>Dr</prefix>
+                                            <given>Penny</given>
+                                            <family>Puffer</family>
+                                        </name>
+                                    </assignedPerson>
+                                </assignedEntity>
+                            </performer>
+                            <!-- Penny Puffer office location as a service delivery location -->
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <code code="1212-0" codeSystem="2.16.840.1.113883.6.259" displayName="Any Age Mixed Acuity Unit"/>
+                                    <telecom nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Dr. Penny Puffer Office</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <!-- this references the indication (reason) for the planned encounter; example data suggests the reason was the encounter diagnosis
+            					L)	Encounter Diagnosis
+            						 - Costal Chondritis, [SNOMED-CT: 64109004], Start: 8/15/2012, Active
+            			 -->
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <id extension="45678" root="1.3.6.1.4.1.42424242.4.99930.4.4.1.2.1"/>
+                                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="282291009" displayName="Diagnosis"/>
+                                    <text>
+                                        <reference value="#ID0EAAAAAAAAACA"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20120815"/>
+                                    </effectiveTime>
+                                    <!-- includes the code for Costal Chondritis -->
+                                    <value xsi:type="CD" code="64109004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Costal Chondritis"/>
+                                </observation>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/Referals - Planned and Completed/Referral Request and Close Referral with a Note/Intervention Planned Referral and Note Completeting Referral(C-CDAR2.1).xml
+++ b/Referals - Planned and Completed/Referral Request and Close Referral with a Note/Intervention Planned Referral and Note Completeting Referral(C-CDAR2.1).xml
@@ -1,188 +1,198 @@
-<!-- This example is created to help with the documentation associated with the following quality measure -->
-<!-- Closing the Referral Loop: https://ecqi.healthit.gov/ecqm/measures/cms50v7 --> 
-<!-- This includes a first section of planned referral that opens the loop and a second section of planned referral which closes loop --> 
-<!-- While both XML sections are included below, in real implementations, they would be expected to be split between two separate documents --> 
-<component>
-    <section>
-        <!-- We've attempted to align/harmonize this example with both C-CDA and guidance from the IHE 360X -->
-        <!-- See information on IHE 360x profile here: https://www.ihe.net/uploadedFiles/Documents/PCC/IHE_PCC_Suppl_360X.pdf --> 
-        <!-- See pages 8 and 44 making recommendation for Patient Referral Act -->  
-        <!-- The interventions section is used below since that was the recommended of IHE 360XS document -->
-        <!-- But this entry could also be used inside of a Reason for Referral section or other open-template section like Plan of Treatment --> 
-        <templateId root="2.16.840.1.113883.10.20.21.2.3" extension="2015-08-01"/>
-        <templateId root="2.16.840.1.113883.10.20.22.2.3"/>
-        <code code="62387-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Interventions Provided"/>
-        <title>Interventions</title>
-        <!-- one patient referral act in the human readable text and as a discrete entry -->
-        <text>
-            <table>
-                <caption>Planned Referral</caption>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Date</th>
-                        <th>Details</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr ID="ID0EFFFFFFCAB3">
-                        <td ID="ID0EFAAAAACAB3">Referral to Specialist</td>
-                        <td>June 23, 2018</td>
-                        <td>Dr. Henry Levine Eighth, as soon as possible</td>
-                    </tr>
-                </tbody>
-            </table>
-        </text>
-        <!-- a patient referral act -->
-        <entry>
-            <act moodCode="INT" classCode="PCPR">
-                <templateId root="2.16.840.1.113883.10.20.22.4.140" />
-                <!-- This id may be referenced in the note received afterward --> 
-                <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4e" />
-                <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" >
-                    <originalText>
-                        <reference value="#ID0EFAAAAACAB3"/>
-                    </originalText>
-                </code>
-                <text>
-                    <!-- referencing the entire text -->
-                    <reference value="#ID0EFFFFFFCAB3"/>
-                </text>
-                <statusCode code="active" />
-                <effectiveTime value="20180623" />
-                <priorityCode code="A" codeSystem="2.16.840.1.113883.5.7" codeSystemName="ActPriority" displayName="ASAP"/>
-                <participant typeCode="REFT">
-                    <participantRole>
-                        <!-- Having this be an NPI may be used to identify completion of referral --> 
-                        <id root="2.16.840.1.113883.4.6" extension="1093929010" />
-                        <code code="207Q00000X" displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
-                        <addr>
-                            <streetAddressLine>100 Main St</streetAddressLine>
-                            <city>Horsham</city>
-                            <state>PA</state>
-                            <postalCode>19044</postalCode>
-                            <country>US</country>
-                        </addr>
-                        <telecom nullFlavor="UNK" />
-                        <playingEntitye>
-                            <name>
-                                <family>Eighth</family>
-                                <given>Henry</given>
-                                <given>Levine</given>
-                            </name>
-                        </playingEntitye>
-                    </participantRole>
-                </participant>
-            </act>
-        </entry>
-    </section>
-</component>
-<!-- The section below would likely be included in a separate document, although included here for a single sample --> 
-<component>
-    <section>
-        <!-- Notes Section -->
-        <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
-        <!-- This Notes Section is not intended to replace a C-CDA Consultation Note Document -->
-        <!-- If your system captures Consultation Note information in Discrete sections it's not recommended to lump all the text together here. -->
-        <!-- This Notes Section could be included in a Consultation Note Document with other discrete sections (Results, Vitals etc.)-->
-        <!-- This Notes Section is most appropriate for an encounter specific document. Other sections of doucments may also close notes -->
-        <!-- If this Notes section were included in a CCD, each Note Activity entry should be linked to an appropriate Encounter entry in the Encounters section -->
-        <code code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-            displayName="Consultation note"/>
-        <title>Consultation Notes</title>
-        <text>
-            <list>
-                <item ID="ConsultNote1">
-                    <paragraph>Dr. Henry Level Eighth - June 23, 2018</paragraph>
-                    <paragraph> Dear Reerring Doctor: Thank you for referring Ms. Everywoman for evaluation. As
-                        you know, she is a 40-year-old woman who has had chronic gastrointestinal
-                        symptoms. Approximately 18 years ago, she was hospitalized with a bleeding
-                        ulcer. She had a CT scan of the abdomen, which revealed findings consistent with
-                        focal nodular hyperplasia (FNH). She has had epigastric abdominal pain as well
-                        as a significant change in her bowel movements from baseline constipation to
-                        frequent diarrhea. The past medical history is otherwise negative. She takes no
-                        prescription medications. The remainder of the history is not contributory. </paragraph>
-                    <paragraph>Physical examination revealed a well-appearing woman. The vital signs
-                        were normal. The head and neck were unremarkable. The lung fields were clear.
-                        The heart exam was normal. The abdomen was obese with normal bowel sounds. There
-                        was no tenderness, mass, or hepatosplenomegaly. </paragraph>
-                    <paragraph>Endoscopic evaluation revealed a normal colonoscopy. Biopsies taken
-                        throughout the colon were essentially unremarkable. Stool tests for pathogenic
-                        organisms were negative. Of note, on the upper endoscopy examination, no
-                        significant abnormalities were seen; however, upon biopsy, features of celiac
-                        disease were noted.</paragraph>
-                    <paragraph> In summary, this 40-year-old woman has evidence of celiac disease. We
-                        discussed the diagnosis in detail in the office. She was advised to undertake a
-                        lifelong gluten-free diet. Followup laboratories in my office were notable for a
-                        low serum iron with a low-normal ferritin. The bone density was normal. Repeat
-                        triple-phase CT scan of the liver revealed no change in the right hepatic lobe
-                        lesion, which is consistent with FNH. I advised periodic reevaluation of the
-                        liver with imaging, as well as followup for any potential development of
-                        nutritional deficiencies. She should take an iron supplement and continue on a
-                        lifelong gluten-free diet. </paragraph>
-                    <paragraph>Thank you for the courtesy of this referral. I would be pleased to see
-                        Ms. Everywoman in followup.</paragraph>
-                </item>
-            </list>
-        </text>
-        <!-- Note Activity entry -->
-        <entry>
-            <act classCode="ACT" moodCode="EVN">
-                <templateId root="2.16.840.1.113883.10.20.22.4.202" extension="2016-11-01"/>
-                <code code="34109-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Note">
-                    <!-- Code must match or be equivalent to section code -->
-                    <translation code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Consultation note"/>
-                    <!-- Additional SNOMED code which is equivalent to the LOINC consultation note code -->
-                    <!-- The quality measure CMS550 v7 requires a concept from 2.16.840.1.113883.3.464.1003.121.12.1006 --> 
-                    <translation code="371530004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Clinical consultation report (record artifact)" />
-                </code>
-                <text>
-                    <reference value="#ConsultNote1"/>
-                </text>
-                <statusCode code="completed"/>
-                <!-- Clinically-relevant time of the note -->
-                <effectiveTime value="20160908"/>
-                <!-- Author Participation -->
-                <author>
-                    <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
-                    <!-- Time note was actually written -->
-                    <time value="20180623083215-0500"/>
-                    <assignedAuthor>
-                        <!-- This NPI helps track the planned referral to the person who actually performed -->
-                        <id root="2.16.840.1.113883.4.6" extension="1093929010" />
-                        <code code="207Q00000X" displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
-                        <addr nullFlavor="UNK" />
-                        <telecom nullFlavor="UNK" />
-                        <assignedPerson>
-                            <name>
-                                <family>Eighth</family>
-                                <given>Henry</given>
-                                <given>Levine</given>
-                            </name>
-                        </assignedPerson>
-                        <representedOrganization>
-                            <id root="2.16.840.1.113883.3.1.1.1.1." extension="0001" />
-                            <name>Default Practice</name>
-                            <telecom use="WP" nullFlavor="UNK" />
-                            <addr>
-                                <streetAddressLine>100 Main St</streetAddressLine>
-                                <city>Horsham</city>
-                                <state>PA</state>
-                                <postalCode>19044</postalCode>
-                                <country>US</country>
-                            </addr>
-                        </representedOrganization>
-                    </assignedAuthor>
-                </author>
-                <reference typeCode="REFR">
-                    <externalAct classCode="ACT" moodCode="EVN">
-                        <!-- This refers to the Patient Referral Act act/id of the planned referral -->
-                        <!-- The quality measure CMS550 v7 requires this identifier to link (related) the completed encounter to the requested referral --> 
-                        <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4e"/>
-                        <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" />
-                    </externalAct>
-                </reference>
-            </act>
-        </entry>
-    </section>
-</component>
+<ClinicalDocument>
+    <!-- This ClinicalDocument's structure is stubbed with the minimum elements necessary
+         to demonstrate the locations of the entries across multiple different sections;
+         however, required content like the document header and section LOINC codes
+         has been omitted. -->
+    <component>
+        <structuredBody>
+            <!-- This example is created to help with the documentation associated with the following quality measure -->
+            <!-- Closing the Referral Loop: https://ecqi.healthit.gov/ecqm/measures/cms50v7 --> 
+            <!-- This includes a first section of planned referral that opens the loop and a second section of planned referral which closes loop --> 
+            <!-- While both XML sections are included below, in real implementations, they would be expected to be split between two separate documents --> 
+            <component>
+                <section>
+                    <!-- We've attempted to align/harmonize this example with both C-CDA and guidance from the IHE 360X -->
+                    <!-- See information on IHE 360x profile here: https://www.ihe.net/uploadedFiles/Documents/PCC/IHE_PCC_Suppl_360X.pdf --> 
+                    <!-- See pages 8 and 44 making recommendation for Patient Referral Act -->  
+                    <!-- The interventions section is used below since that was the recommended of IHE 360XS document -->
+                    <!-- But this entry could also be used inside of a Reason for Referral section or other open-template section like Plan of Treatment --> 
+                    <templateId root="2.16.840.1.113883.10.20.21.2.3" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3"/>
+                    <code code="62387-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Interventions Provided"/>
+                    <title>Interventions</title>
+                    <!-- one patient referral act in the human readable text and as a discrete entry -->
+                    <text>
+                        <table>
+                            <caption>Planned Referral</caption>
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Date</th>
+                                    <th>Details</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr ID="ID0EFFFFFFCAB3">
+                                    <td ID="ID0EFAAAAACAB3">Referral to Specialist</td>
+                                    <td>June 23, 2018</td>
+                                    <td>Dr. Henry Levine Eighth, as soon as possible</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <!-- a patient referral act -->
+                    <entry>
+                        <act moodCode="INT" classCode="PCPR">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.140" />
+                            <!-- This id may be referenced in the note received afterward --> 
+                            <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4e" />
+                            <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" >
+                                <originalText>
+                                    <reference value="#ID0EFAAAAACAB3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <!-- referencing the entire text -->
+                                <reference value="#ID0EFFFFFFCAB3"/>
+                            </text>
+                            <statusCode code="active" />
+                            <effectiveTime value="20180623" />
+                            <priorityCode code="A" codeSystem="2.16.840.1.113883.5.7" codeSystemName="ActPriority" displayName="ASAP"/>
+                            <participant typeCode="REFT">
+                                <participantRole>
+                                    <!-- Having this be an NPI may be used to identify completion of referral --> 
+                                    <id root="2.16.840.1.113883.4.6" extension="1093929010" />
+                                    <code code="207Q00000X" displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
+                                    <addr>
+                                        <streetAddressLine>100 Main St</streetAddressLine>
+                                        <city>Horsham</city>
+                                        <state>PA</state>
+                                        <postalCode>19044</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom nullFlavor="UNK" />
+                                    <playingEntitye>
+                                        <name>
+                                            <family>Eighth</family>
+                                            <given>Henry</given>
+                                            <given>Levine</given>
+                                        </name>
+                                    </playingEntitye>
+                                </participantRole>
+                            </participant>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <!-- The section below would likely be included in a separate document, although included here for a single sample --> 
+            <component>
+                <section>
+                    <!-- Notes Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <!-- This Notes Section is not intended to replace a C-CDA Consultation Note Document -->
+                    <!-- If your system captures Consultation Note information in Discrete sections it's not recommended to lump all the text together here. -->
+                    <!-- This Notes Section could be included in a Consultation Note Document with other discrete sections (Results, Vitals etc.)-->
+                    <!-- This Notes Section is most appropriate for an encounter specific document. Other sections of doucments may also close notes -->
+                    <!-- If this Notes section were included in a CCD, each Note Activity entry should be linked to an appropriate Encounter entry in the Encounters section -->
+                    <code code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Consultation note"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <list>
+                            <item ID="ConsultNote1">
+                                <paragraph>Dr. Henry Level Eighth - June 23, 2018</paragraph>
+                                <paragraph> Dear Reerring Doctor: Thank you for referring Ms. Everywoman for evaluation. As
+                                    you know, she is a 40-year-old woman who has had chronic gastrointestinal
+                                    symptoms. Approximately 18 years ago, she was hospitalized with a bleeding
+                                    ulcer. She had a CT scan of the abdomen, which revealed findings consistent with
+                                    focal nodular hyperplasia (FNH). She has had epigastric abdominal pain as well
+                                    as a significant change in her bowel movements from baseline constipation to
+                                    frequent diarrhea. The past medical history is otherwise negative. She takes no
+                                    prescription medications. The remainder of the history is not contributory. </paragraph>
+                                <paragraph>Physical examination revealed a well-appearing woman. The vital signs
+                                    were normal. The head and neck were unremarkable. The lung fields were clear.
+                                    The heart exam was normal. The abdomen was obese with normal bowel sounds. There
+                                    was no tenderness, mass, or hepatosplenomegaly. </paragraph>
+                                <paragraph>Endoscopic evaluation revealed a normal colonoscopy. Biopsies taken
+                                    throughout the colon were essentially unremarkable. Stool tests for pathogenic
+                                    organisms were negative. Of note, on the upper endoscopy examination, no
+                                    significant abnormalities were seen; however, upon biopsy, features of celiac
+                                    disease were noted.</paragraph>
+                                <paragraph> In summary, this 40-year-old woman has evidence of celiac disease. We
+                                    discussed the diagnosis in detail in the office. She was advised to undertake a
+                                    lifelong gluten-free diet. Followup laboratories in my office were notable for a
+                                    low serum iron with a low-normal ferritin. The bone density was normal. Repeat
+                                    triple-phase CT scan of the liver revealed no change in the right hepatic lobe
+                                    lesion, which is consistent with FNH. I advised periodic reevaluation of the
+                                    liver with imaging, as well as followup for any potential development of
+                                    nutritional deficiencies. She should take an iron supplement and continue on a
+                                    lifelong gluten-free diet. </paragraph>
+                                <paragraph>Thank you for the courtesy of this referral. I would be pleased to see
+                                    Ms. Everywoman in followup.</paragraph>
+                            </item>
+                        </list>
+                    </text>
+                    <!-- Note Activity entry -->
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202" extension="2016-11-01"/>
+                            <code code="34109-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Note">
+                                <!-- Code must match or be equivalent to section code -->
+                                <translation code="11488-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Consultation note"/>
+                                <!-- Additional SNOMED code which is equivalent to the LOINC consultation note code -->
+                                <!-- The quality measure CMS550 v7 requires a concept from 2.16.840.1.113883.3.464.1003.121.12.1006 --> 
+                                <translation code="371530004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Clinical consultation report (record artifact)" />
+                            </code>
+                            <text>
+                                <reference value="#ConsultNote1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <!-- Clinically-relevant time of the note -->
+                            <effectiveTime value="20160908"/>
+                            <!-- Author Participation -->
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- Time note was actually written -->
+                                <time value="20180623083215-0500"/>
+                                <assignedAuthor>
+                                    <!-- This NPI helps track the planned referral to the person who actually performed -->
+                                    <id root="2.16.840.1.113883.4.6" extension="1093929010" />
+                                    <code code="207Q00000X" displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine" codeSystem="2.16.840.1.113883.6.101" codeSystemName="NUCC" />
+                                    <addr nullFlavor="UNK" />
+                                    <telecom nullFlavor="UNK" />
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Eighth</family>
+                                            <given>Henry</given>
+                                            <given>Levine</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.3.1.1.1.1." extension="0001" />
+                                        <name>Default Practice</name>
+                                        <telecom use="WP" nullFlavor="UNK" />
+                                        <addr>
+                                            <streetAddressLine>100 Main St</streetAddressLine>
+                                            <city>Horsham</city>
+                                            <state>PA</state>
+                                            <postalCode>19044</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <reference typeCode="REFR">
+                                <externalAct classCode="ACT" moodCode="EVN">
+                                    <!-- This refers to the Patient Referral Act act/id of the planned referral -->
+                                    <!-- The quality measure CMS550 v7 requires this identifier to link (related) the completed encounter to the requested referral --> 
+                                    <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4e"/>
+                                    <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" />
+                                </externalAct>
+                            </reference>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/Results/Result COVID Positive/Results of COVID Test Positive Normal(C-CDA2.1).xml
+++ b/Results/Result COVID Positive/Results of COVID Test Positive Normal(C-CDA2.1).xml
@@ -50,8 +50,8 @@
                     <templateId root="2.16.840.1.113883.10.20.22.4.2" extension="2015-08-01"/>
                     <id root="5a6be91a-32d5-4d24-a8bd-07d10a33414d"/>
                     <!-- This is a LOINC code uses respiratory sample which would include nasal pharynx swab. Other codes that could be used in different circumstances include -->
-                    <!-- All potential codes for different sample sites or methods include: 94306-8, 94307-6, 94308-4, 94309-2, 94310-0, 94311-8, 94312-6, 94313-4, 94314-2, 94315-9, 94316-7, 94499-1, 94500-6
-                        <!-- 94501-4, 94502-2, 94503-0, 94504-8, 94505-5, 94506-3, 94507-1, 94508-9, 94509-7, 94510-5, 94511-3, 94531-1, 94532-9, 94533-7, 94534-5, 94547-7	-->
+                    <!-- All potential codes for different sample sites or methods include: 94306-8, 94307-6, 94308-4, 94309-2, 94310-0, 94311-8, 94312-6, 94313-4, 94314-2, 94315-9, 94316-7,
+                         94499-1, 94500-6, 94501-4, 94502-2, 94503-0, 94504-8, 94505-5, 94506-3, 94507-1, 94508-9, 94509-7, 94510-5, 94511-3, 94531-1, 94532-9, 94533-7, 94534-5, 94547-7 -->
                     <!-- You can check LOINC code detail by using their open API, such as https://loinc.org/94500-6/ -->
                     <!-- Please note that these are pre-release LOINC codes and codes may change over time -->
                     <code code="94500-6" displayName="SARS coronavirus 2 RNA" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>

--- a/Social History/Electronic Cigarette/Electronic Cigarette Status(C-CDA2.1).xml
+++ b/Social History/Electronic Cigarette/Electronic Cigarette Status(C-CDA2.1).xml
@@ -37,8 +37,8 @@
             <!-- This LOINC code was suggested by Regenstrief but is undergoing changed expected in 2020 -->
             <!-- As more specific codes are developed in LOINC (and possibly SNOMED), other codes may be more appropriate -->
             <code code="66547-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Things to smoke" >
-                <!-- Discussed 722499006 in translation and agreed not an appropriate trsnlation.
-                    <!-- The code 722499006 aligns with 2019 guidance https://www.healthit.gov/isa/representing-patient-electronic-cigarette-use-vaping -->
+                <!-- Discussed 722499006 in translation and agreed not an appropriate trsnlation. -->
+                <!-- The code 722499006 aligns with 2019 guidance https://www.healthit.gov/isa/representing-patient-electronic-cigarette-use-vaping -->
             </code>
             <text>
                 <reference value="#_a1305452-cddd-4654-980f-bba6745588e8"/>


### PR DESCRIPTION
Common causes of invalid examples include:

* An XML document must have exactly one root
* The ampersand character (&) must be escaped in strings as &amp;
* Several examples had an invalid character instead of a proper quote character (")
* All XML attributes must be separated by at least one space
* Comments cannot contain the string "--"