### PR TITLE
Cleanup unnecessary whitespace and collapse empty tags

### DIFF
--- a/Allergies/Allergy to food egg/Allergy to food egg(C-CDA2.1).xml
+++ b/Allergies/Allergy to food egg/Allergy to food egg(C-CDA2.1).xml
@@ -73,7 +73,7 @@
 						<low value="1998"/>
 					</effectiveTime>
 					<!-- This specifies that the allergy is to a food in contrast to other allergies (drug) -->
-					<value xsi:type="CD" code="414285001" displayName="Food allergy (disorder)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></value>
+					<value xsi:type="CD" code="414285001" displayName="Food allergy (disorder)" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
 					<author>
 						<templateId root="2.16.840.1.113883.10.20.22.4.119"/>
 						<time value="20140104"/>

--- a/Allergies/Allergy to specific drug class Penicillins/Allergy to specific drug class Penicillins(C-CDA2.1).xml
+++ b/Allergies/Allergy to specific drug class Penicillins/Allergy to specific drug class Penicillins(C-CDA2.1).xml
@@ -73,7 +73,7 @@
 						<low value="2006"/>
 					</effectiveTime>
 					<!-- This specifies that the allergy is to a medication in contrast to other allergies (substance) -->
-					<value xsi:type="CD" code="416098002" displayName="drug allergy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></value>
+					<value xsi:type="CD" code="416098002" displayName="drug allergy" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
 					<author>
 						<templateId root="2.16.840.1.113883.10.20.22.4.119"/>
 						<time value="20140104"/>

--- a/Documents/Consultation Note/Consultation_Note.xml
+++ b/Documents/Consultation Note/Consultation_Note.xml
@@ -15,7 +15,7 @@
  This sample is designed to be used in conjunction with the C-CDA Clinical Notes Implementation Guide.
  ********************************************************
  -->
-<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" >
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc">
 	<!-- ** CDA Header ** -->
 	<realmCode code="US"/>
 	<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>

--- a/Documents/History and Physical/History_and_Physical.xml
+++ b/Documents/History and Physical/History_and_Physical.xml
@@ -1963,7 +1963,7 @@ SOCIAL HISTORY
 							<!--  ********  Social history observation template   ******** -->
 							<id root="37f76c51-6411-4e1d-8a37-957fd49d2cef"/>
 						  <code code="74013-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
-						    displayName="Alcoholic drinks per day" >
+						    displayName="Alcoholic drinks per day">
 								<originalText>
 									<reference value="#soc3"/>
 								</originalText>

--- a/Encounters/Inpatient Encounter Discharged to Rehab Location/Inpatient_Encounter_Discharged_to_Rehab_Location(C-CDA2.1).xml
+++ b/Encounters/Inpatient Encounter Discharged to Rehab Location/Inpatient_Encounter_Discharged_to_Rehab_Location(C-CDA2.1).xml
@@ -50,9 +50,9 @@
                 </text>
                 <effectiveTime value="201209271300-0500"/>
                 <!-- This shows use of the discharge disposition extension AND shows using both the suggested encoding from C-CDA R2.1 and local Good Health Hospital codes. -->
-                <sdtc:dischargeDispositionCode code="04" codeSystem="2.16.840.1.113883.12.112"  codeSystemName="HL7 Discharge Disposition" displayName="Discharged/transferred to an intermediate-care facility (ICF)" >
+                <sdtc:dischargeDispositionCode code="04" codeSystem="2.16.840.1.113883.12.112"  codeSystemName="HL7 Discharge Disposition" displayName="Discharged/transferred to an intermediate-care facility (ICF)">
                     <originalText>
-                        <reference value="#Encounter1_DischargedDispositionCode"></reference>
+                        <reference value="#Encounter1_DischargedDispositionCode" />
                     </originalText>
                     <!-- Good Health Hospital (local OID) to represent their local code system. -->
                     <translation code="HOSSVR" codeSystem="2.16.840.1.113883.19.5" codeSystemName="Community Medical Center Local Discharge Codes" displayName="SUNNYVIEW REHAB HOSPITAL"/>

--- a/Encounters/Outpatient Encounter Patient Disenrolled/Outpatient Encounter Patient Disenrolled(C-CDA2.1).xml
+++ b/Encounters/Outpatient Encounter Patient Disenrolled/Outpatient Encounter Patient Disenrolled(C-CDA2.1).xml
@@ -52,7 +52,7 @@
                 <!--  This shows use of the discharge disposition extension AND shows using both the suggested encoding from C-CDA R2.1 and some local Good Health Hospital codes. -->
                 <sdtc:dischargeDispositionCode nullFlavor="OTH">
                     <originalText>
-                        <reference value="#Encounter1_DischargeDispositionCode"></reference>
+                        <reference value="#Encounter1_DischargeDispositionCode" />
                     </originalText>
                     <!-- Good Health Hospital (local OID) to represent their local code system. -->
                     <translation code="DE" codeSystem="2.16.840.1.113883.19.5" codeSystemName="Community Urgent Care Local Discharge Code" displayName="Disenrolled"/>

--- a/Encounters/Outpatient Encounter with Diagnoses/Outpatient Encounter with Diagnoses(C-CDA R2.1).xml
+++ b/Encounters/Outpatient Encounter with Diagnoses/Outpatient Encounter with Diagnoses(C-CDA R2.1).xml
@@ -44,7 +44,7 @@
                 <originalText><reference value="#Encounter1_type"/>
                 </originalText>
             </code>
-            <text><reference value="#Encounter1"></reference></text>
+            <text><reference value="#Encounter1" /></text>
             <!-- August 15, 2012 - added time (pacific time) since but not present in test data -->
             <effectiveTime value="201208151000-0800"/>
             <!-- Not specified in test data, but could infer Dr. Khan from the test scenario narrative-->
@@ -55,7 +55,7 @@
                     <code code="207R00000X" codeSystem="2.16.840.1.113883.6.101"
                         codeSystemName="Health Care Provider Taxonomy" 
                         displayName="Internal Medicine">
-                        <originalText><reference value="Encounter1_performer_type"></reference></originalText>
+                        <originalText><reference value="Encounter1_performer_type" /></originalText>
                     </code>
                     <assignedPerson>
                         <name>
@@ -116,7 +116,7 @@
                             <!-- Test data is SNOMED but in practice this is probably an ICD9/10 code -->
                             <value xsi:type="CD" code="64109004" displayName="Costal Chondritis"
                                 codeSystem="2.16.840.1.113883.6.96">
-                                <originalText><reference value="#Encounter1_diagnosis"></reference></originalText>
+                                <originalText><reference value="#Encounter1_diagnosis" /></originalText>
                             </value>
                             <entryRelationship typeCode="REFR">
                                 <observation classCode="OBS" moodCode="EVN"> 
@@ -130,7 +130,7 @@
                                     <statusCode code="completed"/>
                                     <value xsi:type="CD" code="55561003" displayName="Active"
                                         codeSystem="2.16.840.1.113883.6.96">
-                                        <originalText><reference value="#Encounter1_diagnosis_status"></reference></originalText>
+                                        <originalText><reference value="#Encounter1_diagnosis_status" /></originalText>
                                     </value>
                                 </observation>                                             
                             </entryRelationship>

--- a/Family History/Family History Generic/Family History generic(C-CDA2.1).xml
+++ b/Family History/Family History Generic/Family History generic(C-CDA2.1).xml
@@ -46,7 +46,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="02faa204-3333-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>
@@ -75,7 +75,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="04faa204-3333-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>

--- a/Family History/Family History two individuals same relationship to the patient/Family History two individuals same relationship to the patient(C-CDA2.1).xml
+++ b/Family History/Family History two individuals same relationship to the patient/Family History two individuals same relationship to the patient(C-CDA2.1).xml
@@ -49,7 +49,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="02faa204-0000-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>
@@ -73,7 +73,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="03faa204-0000-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>
@@ -126,7 +126,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="03faa204-1111-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<statusCode code="completed"/>

--- a/Family History/Normal Family History Father deceased-Mother alive/Normal Family History Father deceased Mother alive(C-CDA2.1).xml
+++ b/Family History/Normal Family History Father deceased-Mother alive/Normal Family History Father deceased Mother alive(C-CDA2.1).xml
@@ -79,7 +79,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="02faa204-db62-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>
@@ -131,7 +131,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="04faa204-db62-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>
@@ -192,7 +192,7 @@
 					<templateId root="2.16.840.1.113883.10.20.22.4.46" extension="2015-08-01"/>
 					<!-- Unique ID for this individual observation -->
 					<id root="05faa204-db62-4610-864f-cb50b650d0fa" />
-					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition" >
+					<code code="64572001" codeSystem="2.16.840.1.113883.6.96" displayName="Condition">
 						<translation code="75315-2" codeSystem="2.16.840.1.113883.6.1" displayName="Condition Family Member" />
 					</code>
 					<text>

--- a/Functional Status/Functional Impairment/Functional Impairment Dependent on Walking Stick (C-CDAR2.1).xml
+++ b/Functional Status/Functional Impairment/Functional Impairment Dependent on Walking Stick (C-CDAR2.1).xml
@@ -22,7 +22,7 @@
                     <td ID="FS_Type">Functional Status</td> 
                     <td>August 15 2012, 5:32pm</td>
                     <td ID="FS_Finding1">Dependence on walking stick</td>
-                    <td></td>
+                    <td />
                 </tr>
             </tbody>
         </table>
@@ -35,7 +35,7 @@
             <id root="e4f9eb37-52ca-4e95-90f3-570dace107e6"/>
             <code code="54522-8" displayName="Functional status" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
                 <originalText>
-                    <reference value="#FS_Type1"></reference>
+                    <reference value="#FS_Type1" />
                 </originalText>
             </code>
             <text>

--- a/General/External Document Reference/PROBLEMS_in_Empty_C-CDA_2.1 (C-CDAR2.1).xml
+++ b/General/External Document Reference/PROBLEMS_in_Empty_C-CDA_2.1 (C-CDAR2.1).xml
@@ -597,7 +597,7 @@
 								<observation classCode="OBS" moodCode="EVN">
 									<templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
 									<id root="ac416033-3cc1-4485-ab31-36ce7669f55c" />
-									<code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem" >
+									<code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
 										<translation code="75326-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem"/>
 									</code>
 									<text>

--- a/Goals/Goals Narrative Only/Goals Narrative Only(C-CDA2.1).xml
+++ b/Goals/Goals Narrative Only/Goals Narrative Only(C-CDA2.1).xml
@@ -13,7 +13,7 @@
                 <!-- If you have an id for your goal, include here -->
                 <id nullFlavor="UNK"/>
                 <code nullFlavor="UNK"/>
-                <text><reference value="#Goals"></reference></text>
+                <text><reference value="#Goals" /></text>
                 <statusCode code="active"/>
                 <!-- Author could be included to indicate a patient authored goal or a provider different than the document or section author. -->
                 <!-- See HL7 DSTU comment which relaxed the requirement to include the author (867) -->

--- a/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/Admission Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Admission Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.43/Admission Diagnosis Section (V3) Example.xml
@@ -1,7 +1,7 @@
 <section>
   <templateId root="2.16.840.1.113883.10.20.22.2.43" extension="2015-08-01"/>
   <code code="46241-6" codeSystem="2.16.840.1.113883.6.1" displayName="Hospital Admission Diagnosis">
-    <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1" displayName="Admission Diagnosis"></translation>
+    <translation code="42347-5" codeSystem="2.16.840.1.113883.6.1" displayName="Admission Diagnosis" />
   </code>
   <title>HOSPITAL ADMISSION DIAGNOSIS</title>
   <text>Appendicitis</text>

--- a/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/Advance Directive Observation (V3) Example.xml
+++ b/Guide Examples/Advance Directive Observation (V3)_2.16.840.1.113883.10.20.22.4.48/Advance Directive Observation (V3) Example.xml
@@ -9,7 +9,7 @@
       <translation code="75320-2" 
                                     displayName="Advance Directive"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
     </code>
     <statusCode code="completed" />
     <effectiveTime>

--- a/Guide Examples/Care Team Member Act (V2)_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act Example.xml
+++ b/Guide Examples/Care Team Member Act (V2)_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act Example.xml
@@ -30,7 +30,7 @@
             <originalText
                             
               xmlns="urn:hl7-org:v3">
-              <reference value="#CT1_M01"></reference>
+              <reference value="#CT1_M01" />
             </originalText>
           </functionCode>
           <!-- A care team member role -->

--- a/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act.xml
+++ b/Guide Examples/Care Team Member Act_2.16.840.1.113883.10.20.22.4.500.1/Care Team Member Act.xml
@@ -25,7 +25,7 @@
                           codeSystem="2.16.840.1.113883.5.88" codeSystemName="ParticipationFunction">
             <originalText 
               xmlns="urn:hl7-org:v3">
-              <reference value="#CT1_M01"></reference>
+              <reference value="#CT1_M01" />
             </originalText>
           </functionCode>
           <!-- A care team member role -->

--- a/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/Care Team Organizer Example 1.xml
+++ b/Guide Examples/Care Team Organizer_2.16.840.1.113883.10.20.22.4.500/Care Team Organizer Example 1.xml
@@ -6,7 +6,7 @@
     <id root="1.1.1.1.1.1"/>
     <code code="86744-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Care Team">
       <originalText>
-        <reference value="#CareTeamName1"></reference>
+        <reference value="#CareTeamName1" />
       </originalText>
     </code>
     <!--Care Team Status - https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.1.11.15933/expansion-->
@@ -36,7 +36,7 @@
                           codeSystem="2.16.840.1.113883.5.88" codeSystemName="ParticipationFunction">
             <originalText 
               xmlns="urn:hl7-org:v3">
-              <reference value="#CT1_M01"></reference>
+              <reference value="#CT1_M01" />
             </originalText>
           </functionCode>
           <!-- A care team member role -->

--- a/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/Discharge Diagnosis Section (V3) Example.xml
+++ b/Guide Examples/Discharge Diagnosis Section (V3)_2.16.840.1.113883.10.20.22.2.24/Discharge Diagnosis Section (V3) Example.xml
@@ -6,7 +6,7 @@
                                 codeSystemName="LOINC">
     <translation code="78375-3" displayName="Discharge Diagnosis"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
   </code>
   <title>Discharge Diagnosis</title>
   <text>Diverticula of intestine</text>

--- a/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge Medication Section (V3) (entries required) Example.xml
+++ b/Guide Examples/Discharge Medications Section (entries required) (V3)_2.16.840.1.113883.10.20.22.2.11.1/Discharge Medication Section (V3) (entries required) Example.xml
@@ -5,7 +5,7 @@
                                 codeSystemName="LOINC">
     <translation code="75311-1" displayName="Discharge Medications"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
   </code>
   <title>Discharge Medications</title>
   <text>

--- a/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/Family History Observation (V3) Example.xml
+++ b/Guide Examples/Family History Observation (V3)_2.16.840.1.113883.10.20.22.4.46/Family History Observation (V3) Example.xml
@@ -4,7 +4,7 @@
   <id root="d42ebf70-5c89-11db-b0de-0800200c9a66" />
   <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Condition">
     <translation code="64572001" displayName="Condition" 
-                                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"></translation>
+                                    codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
   </code>
   <statusCode code="completed" />
   <effectiveTime value="1967" />

--- a/Guide Examples/Goal Observation (V2)_2.16.840.1.113883.10.20.22.4.121/Social Determinant of Health Text Goal Example.xml
+++ b/Guide Examples/Goal Observation (V2)_2.16.840.1.113883.10.20.22.4.121/Social Determinant of Health Text Goal Example.xml
@@ -17,7 +17,7 @@
         <id nullFlavor="UNK"/>
         <code nullFlavor="UNK"/>
         <text>
-          <reference value="#Goals"></reference>
+          <reference value="#Goals" />
         </text>
         <statusCode code="active"/>
         <!-- Author could be included to indicate a patient authored goal or a provider different than the document or section author. -->

--- a/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/Mental Status Observation (V3) Example.xml
+++ b/Guide Examples/Mental Status Observation (V3)_2.16.840.1.113883.10.20.22.4.74/Mental Status Observation (V3) Example.xml
@@ -21,7 +21,7 @@
           <translation code="75275-8" 
                                     displayName="Cognitive function"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
         </code>
         <statusCode code="completed"/>
                             ...

--- a/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/Mental Status Organizer (V3) Example.xml
+++ b/Guide Examples/Mental Status Organizer (V3)_2.16.840.1.113883.10.20.22.4.75/Mental Status Organizer (V3) Example.xml
@@ -21,7 +21,7 @@
           <translation code="75275-8" 
                                     displayName="Cognitive function"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
         </code>
         <statusCode code="completed"/>
                             ...

--- a/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/Number of Pressure Ulcers Observation (V3) Example.xml
+++ b/Guide Examples/Number of Pressure Ulcers Observation (V3)_2.16.840.1.113883.10.20.22.4.76/Number of Pressure Ulcers Observation (V3) Example.xml
@@ -8,7 +8,7 @@
       <translation code="75277-4" 
                                     displayName="Number of pressure ulcers"
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
     </code>
     <statusCode code="completed" />
     <value xsi:type="INT" value="3" />

--- a/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/Planned Encounter (V2) Example.xml
+++ b/Guide Examples/Planned Encounter (V2)_2.16.840.1.113883.10.20.22.4.40/Planned Encounter (V2) Example.xml
@@ -3,7 +3,7 @@
     <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09" />
     <!-- Planned Encounter V2 template -->
     <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4d" />
-    <code code="185349003" displayName="encounter for check-up (procedure)" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96"></code>
+    <code code="185349003" displayName="encounter for check-up (procedure)" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" />
     <statusCode code="active" />
     <effectiveTime value="20130615" />
     <performer>

--- a/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/Policy Activity (V3) Example.xml
+++ b/Guide Examples/Policy Activity (V3)_2.16.840.1.113883.10.20.22.4.61/Policy Activity (V3) Example.xml
@@ -5,7 +5,7 @@
              codeSystemName="Insurance Type Code (x12N-1336)"
              codeSystem="2.16.840.1.113883.6.255.1336">
     <translation code="2" displayName="Medicare" 
-                                    codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology (PHDSC)"></translation>
+                                    codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology (PHDSC)" />
   </code>
   <statusCode code="completed" />
   <!-- Insurance company information -->

--- a/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/SOP Instance Observation Example.xml
+++ b/Guide Examples/SOP Instance Observation_2.16.840.1.113883.10.20.6.2.8/SOP Instance Observation Example.xml
@@ -3,7 +3,7 @@
   <id root="1.2.840.113619.2.62.994044785528.20060823.200608232232322.3"/>
   <code code="1.2.840.10008.5.1.4.1.1.1"
 codeSystem="1.2.840.10008.2.6.1" codeSystemName="DCMUID"
-displayName="Computed Radiography Image Storage"></code>
+displayName="Computed Radiography Image Storage" />
   <text mediaType="application/dicom">
     <reference value="http://www.example.org/wado?requestType=WADO&amp;studyUID=1.2.840.113619.2.62.994044785528.114289542805&amp;seriesUID=1.2.840.113619.2.62.994044785528.20060823223142485051&amp;objectUID=1.2.840.113619.2.62.994044785528.20060823.200608232232322.3&amp;contentType=application/dicom"/>
     <!--reference to image 1 (PA) -->

--- a/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
+++ b/Guide Examples/Social History Observation (V3)_2.16.840.1.113883.10.20.22.4.38/Social History Observation (V3) Example.xml
@@ -8,7 +8,7 @@
     <translation code="74013-4"  
         codeSystem="2.16.840.1.113883.6.1" 
         codeSystemName="LOINC" 
-        displayName="Alcoholic drinks per day"></translation>
+        displayName="Alcoholic drinks per day" />
     <statusCode code="completed" />
     <effectiveTime>
       <low value="20120215" />

--- a/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/Vital Signs Organizer (V3) Example.xml
+++ b/Guide Examples/Vital Signs Organizer (V3)_2.16.840.1.113883.10.20.22.4.26/Vital Signs Organizer (V3) Example.xml
@@ -7,7 +7,7 @@
     <translation code="74728-7" 
                                     displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel "
                                     codeSystem="2.16.840.1.113883.6.1"
-                                    codeSystemName="LOINC"></translation>
+                                    codeSystemName="LOINC" />
   </code>
   <statusCode code="completed" />
   <effectiveTime>

--- a/Health Concerns/Health Concerns Narrative Only/Health Concerns Narrative Only(C-CDA2.1).xml
+++ b/Health Concerns/Health Concerns Narrative Only/Health Concerns Narrative Only(C-CDA2.1).xml
@@ -13,7 +13,7 @@
                 <id nullFlavor="UNK"/>
                 <!-- Fixed act/code in C-CDA -->
                 <code code="75310-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Health Concern"/>
-                <text><reference value="#Concern"></reference></text>
+                <text><reference value="#Concern" /></text>
                 <statusCode code="active"/>
             </act>
         </entry>

--- a/Medical Equipment/Non-Medicinal Supply - Cane and Eyeglasses/Non-Medicinal Supply - Cane and Eyeglasses (C-CDAR2.1).xml
+++ b/Medical Equipment/Non-Medicinal Supply - Cane and Eyeglasses/Non-Medicinal Supply - Cane and Eyeglasses (C-CDAR2.1).xml
@@ -40,7 +40,7 @@
 			<templateId root="2.16.840.1.113883.10.20.22.4.50" extension="2014-06-09"/>
 			<id extension="2744999" root="1.2.840.999.1.13.5552.1.7.2.99999"/>
 			<text>
-				<reference value="#equipment1"></reference>
+				<reference value="#equipment1" />
 			</text>
 			<statusCode code="active"/>
 			<!-- low represents when person first received supply -->
@@ -79,7 +79,7 @@
 				codeSystemName="SNOMEDCT" displayName="Durable medical equipment (physical object)">
 			</code>
 			<text>
-				<reference value="#equipment2"></reference>
+				<reference value="#equipment2" />
 			</text>
 			<statusCode code="active"/>
 			<!-- low represents when person first received supply -->

--- a/Mental Status/Memory Impairment/Memory Impairment(C-CDAR2.1).xml
+++ b/Mental Status/Memory Impairment/Memory Impairment(C-CDAR2.1).xml
@@ -23,7 +23,7 @@
                     <!-- Some systems may just report this to day rather than hour and minute timestamp. Both of which are acceptable. -->
                     <td>August 15 2012, 5:32pm</td>
                     <td ID="MS_Finding1">Memory Impairment</td>
-                    <td></td>
+                    <td />
                 </tr>
             </tbody>
         </table>
@@ -37,7 +37,7 @@
             <!-- In C-CDA R2.1 August 2015 this is a fixed code. SDWG may change to a value set in STU comment 1367 -->
             <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="373930000" displayName="Cognitive function finding">
                 <originalText>
-                    <reference value="#MS_Type1"></reference>
+                    <reference value="#MS_Type1" />
                 </originalText>
                 <translation code="75275-8" 
                     displayName="Cognitive function"

--- a/Mental Status/No Cognitive Impairment/No Cognitive Impairment(C-CDAR2.1).xml
+++ b/Mental Status/No Cognitive Impairment/No Cognitive Impairment(C-CDAR2.1).xml
@@ -24,7 +24,7 @@
                     <td ID="MS_Type1">Cognitive Status</td> 
                     <td>August 15 2012, 5:32pm</td>
                     <td ID="MS_Finding1">No impairment</td>
-                    <td></td>
+                    <td />
                 </tr>
             </tbody>
         </table>
@@ -38,7 +38,7 @@
             <id root="faa09c19-fa1f-4a6c-ae79-10a3b711550f"/>
             <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="373930000" displayName="Cognitive function finding">
                 <originalText>
-                    <reference value="#MS_Type1"></reference>
+                    <reference value="#MS_Type1" />
                 </originalText>
                 <translation code="75275-8" 
                     displayName="Cognitive function"

--- a/Plan of Treatment/Care Plan Goals and Instructions/Care Plan Goals and Instructions(C-CDAR2.1).xml
+++ b/Plan of Treatment/Care Plan Goals and Instructions/Care Plan Goals and Instructions(C-CDAR2.1).xml
@@ -70,7 +70,7 @@
                     <statusCode code="completed"/>
                     <!-- 
 					   <text>
-						  <reference value="#Action1"></reference>
+						  <reference value="#Action1" />
 					   </text>
 								-->
                     <!-- In this example, the instruction was given at the same time that the goal was set.
@@ -111,7 +111,7 @@
                     <statusCode code="completed"/>
                     <!-- 
 						<text>
-						  <reference value="#Action2"></reference>
+						  <reference value="#Action2" />
 						</text>
 					-->
                     <!-- In this example, the instruction was given at the same time that the goal was set.

--- a/Problems/Patient Does Not Have Diabetes/Patient Does Not Have Diabetes(C-CDA2.1).xml
+++ b/Problems/Patient Does Not Have Diabetes/Patient Does Not Have Diabetes(C-CDA2.1).xml
@@ -18,7 +18,7 @@
             <tbody>
                 <tr ID="problems1">
                     <td>12/01/2015 16:05:06</td>
-                    <td></td>
+                    <td />
                     <td>Active</td>
                     <td ID="problem1">No Diabetes (ruled out)</td>
                 </tr>
@@ -33,7 +33,7 @@
             <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
             <id root="36e3e930-7b14-11db-9fe1-0800200c9a66"/>
             <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
-            <text><reference value="#Concern_1"></reference></text>
+            <text><reference value="#Concern_1" /></text>
             <statusCode code="completed"/> <!-- The concern is not active, in terms of there being an active condition to be managed.-->
             <effectiveTime>
                 <low value="20151201071605"/> <!-- Time at which THIS “concern” began being tracked.-->
@@ -77,7 +77,7 @@
                         <translation code="75326-9" codeSystem="2.16.840.1.113883.6.1"
                             codeSystemName="LOINC" displayName="Problem"/>
                     </code>
-                    <text><reference value="#problems1"></reference></text>
+                    <text><reference value="#problems1" /></text>
                     <statusCode code="completed"/>
                     <effectiveTime>
                         <low value="20151201160506"/>
@@ -90,7 +90,7 @@
                         displayName="Diabetes Mellitus Type 2 (Disorder)"
                         codeSystem="2.16.840.1.113883.6.96"
                         codeSystemName="SNOMED CT">
-                        <originalText><reference value="#problem1"></reference></originalText>
+                        <originalText><reference value="#problem1" /></originalText>
                     </value>
                 </observation>
             </entryRelationship>

--- a/Problems/Problem TargetSiteCode Qualifier/Problem TargetSiteCode Qualifier(C-CDAR2.1).xml
+++ b/Problems/Problem TargetSiteCode Qualifier/Problem TargetSiteCode Qualifier(C-CDAR2.1).xml
@@ -41,7 +41,7 @@
                 <observation classCode="OBS" moodCode="EVN">
                     <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01"/>
                     <id root="ac416033-3cc1-4485-ab31-36ce7669f55c" />
-                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem" >
+                    <code codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" code="55607006" displayName="Problem">
                         <translation code="75326-9" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Problem"/>
                     </code>
                     <text>

--- a/Referals - Planned and Completed/Referral Request and Close Referral with a Note/Intervention Planned Referral and Note Completeting Referral(C-CDAR2.1).xml
+++ b/Referals - Planned and Completed/Referral Request and Close Referral with a Note/Intervention Planned Referral and Note Completeting Referral(C-CDAR2.1).xml
@@ -39,7 +39,7 @@
                 <templateId root="2.16.840.1.113883.10.20.22.4.140" />
                 <!-- This id may be referenced in the note received afterward --> 
                 <id root="9a6d1bac-17d3-4195-89a4-1121bc809b4e" />
-                <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96" >
+                <code code="103697008" displayName="Patient referral to specialist" codeSystemName="SNOMED CT" codeSystem="2.16.840.1.113883.6.96">
                     <originalText>
                         <reference value="#ID0EFAAAAACAB3"/>
                     </originalText>

--- a/Results/Result with Multiple Reference Ranges/Lab with Multiple Reference Ranges(C-CDA2.1).xml
+++ b/Results/Result with Multiple Reference Ranges/Lab with Multiple Reference Ranges(C-CDA2.1).xml
@@ -34,7 +34,7 @@
 							<templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
 							<templateId root="2.16.840.1.113883.10.20.22.4.1"/>
 							<id root="7d5a02b0-67a4-11db-bd13-0800200c9a66"/>
-							<code code="5048-4" displayName="Nuclear Ab [Titer] in Serum by Immunofluorescence" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"></code>
+							<code code="5048-4" displayName="Nuclear Ab [Titer] in Serum by Immunofluorescence" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
 							<statusCode code="completed"/>
 							<effectiveTime>
 								<low value="201703191230-0800"/>
@@ -52,7 +52,7 @@
 										</text>
 									<statusCode code="completed"/>
 									<effectiveTime value="201703191230-0800"/>
-									<value xsi:type="ST" >
+									<value xsi:type="ST">
 										Borderline, equal to 1:80
 									</value>
 									<!-- Borderline is considered abnormal -->

--- a/Results/Results Radiology with Image Narrative/Chest X ray with Narrative Report(C-CDA2.1).xml
+++ b/Results/Results Radiology with Image Narrative/Chest X ray with Narrative Report(C-CDA2.1).xml
@@ -23,13 +23,13 @@
 				</tr>
 				<tr ID="Result1">
 					<td>Chest X-Ray 2 Views</td>
-					<td ID="Result1OriginalText" >
+					<td ID="Result1OriginalText">
 						The lungs are clear. The heart is enlarged with evidence of cardiomegaly.
 						Pulmonary vasculature is normal. The aorta is mildly ectatic and tortuous.
 						IMPRESSION: Cardiomegaly. No other acute abnormality. 
 					</td>
-					<td></td>
-					<td></td>
+					<td />
+					<td />
 				</tr>
 				<tr>
 					<th colspan="4">Electronically signed: Hermione Seaven, MD 02-25-2015 10:32a</th>

--- a/Social History/Electronic Cigarette/Electronic Cigarette Status(C-CDA2.1).xml
+++ b/Social History/Electronic Cigarette/Electronic Cigarette Status(C-CDA2.1).xml
@@ -36,7 +36,7 @@
             <id extension="Z504295^^713914004" root="1.2.840.114350.1.13.861.1.7.1.1040.8" /> 
             <!-- This LOINC code was suggested by Regenstrief but is undergoing changed expected in 2020 -->
             <!-- As more specific codes are developed in LOINC (and possibly SNOMED), other codes may be more appropriate -->
-            <code code="66547-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Things to smoke" >
+            <code code="66547-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Things to smoke">
                 <!-- Discussed 722499006 in translation and agreed not an appropriate trsnlation.
                     <!-- The code 722499006 aligns with 2019 guidance https://www.healthit.gov/isa/representing-patient-electronic-cigarette-use-vaping -->
             </code>

--- a/Unstructured/CDA with Embedded PDF 2/CDA_with_Embedded_PDF.xml
+++ b/Unstructured/CDA with Embedded PDF 2/CDA_with_Embedded_PDF.xml
@@ -38,7 +38,7 @@
                 <country>US</country>
             </addr>
             <telecom value="tel:+1(301)111-1111" use="HP"/>
-            <telecom value="mailto:roger.r.mcbee@fakegmail.com"></telecom>
+            <telecom value="mailto:roger.r.mcbee@fakegmail.com" />
             <patient>
                 <name use="L"><given>Roger</given><given>Rienman</given><family>McBee</family></name>
                 <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1"

--- a/Vital Signs/Panel of Vital Signs (Oxygen Concentration Included)/Panel of Vital Signs (Oxygen Concentration Included) (C-CDA2.1).xml
+++ b/Vital Signs/Panel of Vital Signs (Oxygen Concentration Included)/Panel of Vital Signs (Oxygen Concentration Included) (C-CDA2.1).xml
@@ -39,8 +39,7 @@
 					<td>05/20/2014 7:36pm</td>
 					<!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references-->
 					<td>
-						<content ID="SystolicBP_1">120</content>/<content ID="DiastolicBP_1"
-							>80</content>mm[Hg] </td>
+						<content ID="SystolicBP_1">120</content>/<content ID="DiastolicBP_1">80</content>mm[Hg] </td>
 					<td ID="Pulse_1">80 /min</td>
 					<td ID="Temp_1">37.2 C</td>
 					<td ID="RespRate_1">18 /min</td>

--- a/Vital Signs/Panel of Vital Signs in Metric Units/Panel of Vital Signs in Metric Units(C-CDA2.1).xml
+++ b/Vital Signs/Panel of Vital Signs in Metric Units/Panel of Vital Signs in Metric Units(C-CDA2.1).xml
@@ -24,8 +24,7 @@
 					<td>05/20/2014 7:36pm</td>
 					<!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references-->
 					<td>
-						<content ID="SystolicBP_1">120</content>/<content ID="DiastolicBP_1"
-							>80</content>mm[Hg] </td>
+						<content ID="SystolicBP_1">120</content>/<content ID="DiastolicBP_1">80</content>mm[Hg] </td>
 					<td ID="Pulse_1">80 /min</td>
 					<td ID="Temp_1">37.2 C</td>
 					<td ID="RespRate_1">18 /min</td>

--- a/Vital Signs/Panel of Vital Signs in Mixed Metric-Imperial Units/Panel of Vital Signs in Mixed Metric-Imperial Units(C-CDA2.1).xml
+++ b/Vital Signs/Panel of Vital Signs in Mixed Metric-Imperial Units/Panel of Vital Signs in Mixed Metric-Imperial Units(C-CDA2.1).xml
@@ -24,8 +24,7 @@
 					<td>05/20/2014 7:36pm</td>
 					<!-- You can consolidate Systolic and Diastolic in human view if desired but should retain separate references-->
 					<td>
-						<content ID="SystolicBP_2">120</content>/<content ID="DiastolicBP_2"
-							>80</content>mm[Hg] </td>
+						<content ID="SystolicBP_2">120</content>/<content ID="DiastolicBP_2">80</content>mm[Hg] </td>
 					<td ID="Pulse_2">80 /min</td>
 					<td ID="Temp_2">99.0 F</td>
 					<td ID="RespRate_2">18 /min</td>


### PR DESCRIPTION
Another piece of really low-stakes repo tidying... I decided to apply the following two formatting changes (though if anyone disagrees with them stylistically we can talk about it further...)

1. Cleanup whitespace at the end of opening tags--for example, `<td >my content</td>` becomes `<td>my content</td>`
2. Collapse empty tags--for example, `<td></td>` becomes `<td />`